### PR TITLE
Bugfix/error handling

### DIFF
--- a/src/api/chatbot/getthread.py
+++ b/src/api/chatbot/getthread.py
@@ -64,8 +64,8 @@ async def get_thread(
             logger=logger,
         )
     except FileNotFoundError:
-        logger.exception("Thread not found", extra={"thread_id": thread_id})
-        raise HTTPException(status_code=404, detail="Thread not found")
+        logger.exception("Thread not found.", extra={"thread_id": thread_id})
+        raise HTTPException(status_code=404, detail="Thread not found.")
     except ValueError as e:
         logger.exception(f"Error reading thread file: {e}", extra={"thread_id": thread_id})
         raise HTTPException(status_code=500, detail=f"Error reading thread file: {e}")
@@ -74,6 +74,6 @@ async def get_thread(
 
     content = _post_process(content)
 
-    logger.info("Fetched thread content", extra={"thread_id": thread_id, "user_id": Auth.username})
+    logger.info("Fetched thread content.", extra={"thread_id": thread_id, "user_id": Auth.username})
 
     return content

--- a/src/api/chatbot/getthread.py
+++ b/src/api/chatbot/getthread.py
@@ -55,7 +55,7 @@ async def get_thread(
     Storage = await get_thread_storage(vault_url=Auth.vault_url)
 
     try:
-        prep_error = await prepare_for_stream(
+        await prepare_for_stream(
             thread_id=thread_id, 
             user_id=Auth.username,
             Auth=Auth,
@@ -63,16 +63,12 @@ async def get_thread(
             read_history=True,
             logger=logger,
         )
-        if prep_error:
-            logger.info("Prep for stream returned an error!", extra={"thread_id": thread_id})
-            return prep_error
-
     except FileNotFoundError:
-        logger.warning("Thread not found", extra={"thread_id": thread_id})
+        logger.exception("Thread not found", extra={"thread_id": thread_id})
         raise HTTPException(status_code=404, detail="Thread not found")
-    except Exception:
-        logger.exception("Error reading thread file", extra={"thread_id": thread_id})
-        raise HTTPException(status_code=500, detail="Error reading thread file.")
+    except ValueError as e:
+        logger.exception(f"Error reading thread file: {e}", extra={"thread_id": thread_id})
+        raise HTTPException(status_code=500, detail=f"Error reading thread file: {e}")
         
     content = await get_conv_messages(thread_id)
 

--- a/src/api/chatbot/streamresponse.py
+++ b/src/api/chatbot/streamresponse.py
@@ -100,21 +100,22 @@ async def streamresponse(
         },
     )
 
-    async def event_stream():
+    try:
+        await prepare_for_stream(
+            thread_id=thread_id, 
+            user_id=user_name,
+            Auth=Auth,
+            Storage=Storage,
+            read_history=read_history,
+            logger=logger,
+        )
+    except Exception as e:
+        msg = f"Stream preparation has failed: {e}"
+        logger.exception(msg, extra={"thread_id": thread_id, "user_id": user_name})
+        # Normalize response to a clean HTTP 500 instead of a partial stream
+        raise HTTPException(status_code=500, detail="Internal Server Error: {e}")
 
-        try:
-            await prepare_for_stream(
-                thread_id=thread_id, 
-                user_id=user_name,
-                Auth=Auth,
-                Storage=Storage,
-                read_history=read_history,
-                logger=logger,
-            )
-        except Exception as e:
-            msg = f"Prompt/history assembly failed: {e}"
-            logger.exception(msg, extra={"thread_id": thread_id, "user_id": user_name})
-            raise e
+    async def event_stream():
 
         last_check = time.monotonic()
         async for variant in run_stream(

--- a/src/api/chatbot/streamresponse.py
+++ b/src/api/chatbot/streamresponse.py
@@ -102,21 +102,19 @@ async def streamresponse(
 
     async def event_stream():
 
-        prep_error = await prepare_for_stream(
-            thread_id=thread_id, 
-            user_id=user_name,
-            Auth=Auth,
-            Storage=Storage,
-            read_history=read_history,
-            logger=logger,
-        )
-        if prep_error:
-            logger.warning(
-                "prepare_for_stream returned non-stream variant",
-                extra={"thread_id": thread_id, "user_id": user_name},
+        try:
+            await prepare_for_stream(
+                thread_id=thread_id, 
+                user_id=user_name,
+                Auth=Auth,
+                Storage=Storage,
+                read_history=read_history,
+                logger=logger,
             )
-            yield _sse_data(from_sv_to_json(prep_error))
-            return
+        except Exception as e:
+            msg = f"Prompt/history assembly failed: {e}"
+            logger.exception(msg, extra={"thread_id": thread_id, "user_id": user_name})
+            raise e
 
         last_check = time.monotonic()
         async for variant in run_stream(

--- a/src/services/streaming/stream_orchestrator.py
+++ b/src/services/streaming/stream_orchestrator.py
@@ -278,18 +278,11 @@ async def prepare_for_stream(
     log = logger or DEFAULT_LOGGER
     messages: List[Dict[str, Any]] = []
     if read_history and Storage:
-        try:
-            messages = await get_conversation_history(thread_id, Storage)
-        except Exception as e:
-            msg = f"Prompt/history assembly failed: {e}"
-            log.exception(msg)
-            err = SVServerError(message=msg)
-            return err
+        messages = await get_conversation_history(thread_id, Storage)
 
     # Check if the conversation already exists in registry
     # If not initialize it, and add the first messages 
     await initialize_conversation(thread_id, user_id, messages=messages, auth=Auth, logger=log)
-    return None
 
 
 async def get_conversation_history(

--- a/tests/api_integration_tests/test_getthread.py
+++ b/tests/api_integration_tests/test_getthread.py
@@ -1,0 +1,63 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_getthread_returns_404_when_thread_missing(
+    stub_resp,
+    client,
+    patch_db,
+    patch_mongo_uri,
+    patch_mcp_manager,
+    GOOD_HEADERS,
+    monkeypatch,
+):
+    async def _raise_not_found(*args, **kwargs):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(
+        "src.api.chatbot.getthread.prepare_for_stream",
+        _raise_not_found,
+        raising=True,
+    )
+
+    with stub_resp:
+        async with client:
+            r = await client.get(
+                "/api/chatbot/getthread",
+                params={"thread_id": "t-missing"},
+                headers=GOOD_HEADERS,
+            )
+
+            assert r.status_code == 404
+            assert r.json()["detail"] == "Thread not found."
+
+
+@pytest.mark.asyncio
+async def test_getthread_returns_500_when_history_invalid(
+    stub_resp,
+    client,
+    patch_db,
+    patch_mongo_uri,
+    patch_mcp_manager,
+    GOOD_HEADERS,
+    monkeypatch,
+):
+    async def _raise_value_error(*args, **kwargs):
+        raise ValueError("broken history")
+
+    monkeypatch.setattr(
+        "src.api.chatbot.getthread.prepare_for_stream",
+        _raise_value_error,
+        raising=True,
+    )
+
+    with stub_resp:
+        async with client:
+            r = await client.get(
+                "/api/chatbot/getthread",
+                params={"thread_id": "t-bad"},
+                headers=GOOD_HEADERS,
+            )
+
+            assert r.status_code == 500
+            assert "Error reading thread file" in r.json()["detail"]

--- a/tests/api_integration_tests/test_streamresponse.py
+++ b/tests/api_integration_tests/test_streamresponse.py
@@ -1,0 +1,30 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_streamresponse_returns_500_on_prepare_failure(
+    stub_resp,
+    client,
+    patch_db,
+    patch_mongo_uri,
+    GOOD_HEADERS,
+    monkeypatch,
+):
+    async def _raise_error(**kwargs):
+        raise RuntimeError("prep failed")
+
+    monkeypatch.setattr(
+        "src.api.chatbot.streamresponse.prepare_for_stream",
+        _raise_error,
+        raising=True,
+    )
+
+    with stub_resp:
+        async with client:
+            r = await client.get(
+                "/api/chatbot/streamresponse",
+                params={"thread_id": "t-err", "input": "hi", "user_id": "alice"},
+                headers={**GOOD_HEADERS, "x-freva-config-path": "/tmp/config.yml"},
+            )
+
+            assert r.status_code == 500
+            assert "Internal Server Error" in r.json()["detail"]


### PR DESCRIPTION
Error handling around stream preparation (reading an existing thread, registering the conversation) was swallowing stream/getthread errors, leading to partial streams and ambiguous responses.

**Changes:**
- Errors are handled on each endpoint instead of in `prepare_for_stream` function.
- Made streamresponse surface prep failures as an immediate HTTP 500 instead of yielding stream. 
- Added integration tests for getthread 404/500 cases, for streamresponse prep-failure 500, and adjusted stubs to match signatures.