### PR TITLE
Bugfix / Unexpected Stream Cancelling Error (reverted)

### DIFF
--- a/src/services/streaming/stream_orchestrator.py
+++ b/src/services/streaming/stream_orchestrator.py
@@ -253,6 +253,7 @@ async def run_stream(
             end_v = SVStreamEnd(message="Cancelled.")
             log.error("Stream is cancelled.")
             await add_to_conversation(thread_id, [end_v])
+            break
         except Exception as e:
             log.exception("Stream error: %s", e)
             err_v = SVServerError(message=str(e))


### PR DESCRIPTION
This small PR solves a bug which causes the server to go into frenzy when encountered with an unexpected cancellation error.

**The problem:**

When client is shut down without closing the connection in the middle of the stream, it raises `asyncio.CancelledError` with a never-ending flood of errors that freezes the server:

```
freva-gpt-backend-1  | 2026-02-06 16:44:37,078 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,085 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,093 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,099 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,106 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,112 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,120 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,127 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,133 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,140 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,146 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,153 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,167 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,186 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | 2026-02-06 16:44:37,198 ERROR src.api.chatbot.streamresponse [thread=osyZRob0H0yGqqHXEW7MNhUpxEWiJtYP user=janedoe] Stream is cancelled.
```

**Behavior after fix:**
We break the loop when encountered with this error. The server responds normally when client connected again.

```
freva-gpt-backend-1  | 2026-02-06 17:01:50,101 ERROR src.api.chatbot.streamresponse [thread=KBJ5L3PlYLs7o5bftkG0ln353y4CvKbX user=janedoe] Stream is cancelled.
freva-gpt-backend-1  | INFO:     192.168.65.1:60641 - "GET /api/chatbot/ping HTTP/1.1" 200 OK
freva-gpt-backend-1  | INFO:     192.168.65.1:43734 - "GET /api/chatbot/ping HTTP/1.1" 200 OK
```
