### PR TITLE
Endpoint responses and error handling

### DIFF
--- a/src/api/chatbot/availablechatbots.py
+++ b/src/api/chatbot/availablechatbots.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException
 from typing import List
+from yaml.error import YAMLError
 
 from src.core.available_chatbots import available_chatbots
 from src.services.service_factory import AuthRequired
@@ -7,17 +8,43 @@ from src.services.service_factory import AuthRequired
 router = APIRouter()
 
 @router.get("/availablechatbots", response_model=List[str], dependencies=[AuthRequired])
-async def available_chatbots_endpoint(request: Request) -> List[str]:
+async def available_chatbots_endpoint() -> List[str]:
     """
     Available Chatbots
 
     Statically returns the list of available chatbots as a List.
-    Requires a valid auth (same semantics as Rust's `authorize_or_fail!`).
+    Requires a valid authentication.
 
-    The returned strings can be used by the frontend to select a model elsewhere.
-    If no model is specified there, the first item of this list is the default.
+    The returned list of strings can be used by the frontend to select 
+    a model elsewhere. If no model is specified, the first item of this 
+    list is the default.
     """
-    # Return ordered list of model names from litellm_config.yaml
-    chatbot_list = available_chatbots()
+    try:
+        # Return ordered list of model names from litellm_config.yaml
+        chatbot_list = available_chatbots()
 
-    return [c for c in chatbot_list if "embed" not in c]
+        return [c for c in chatbot_list if "embed" not in c]
+    
+    except FileNotFoundError as e:
+        raise HTTPException(
+            status_code=500,
+            detail="LiteLLM config file not found.",
+        )
+
+    except YAMLError as e:
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to parse LiteLLM config file.",
+        ) from e
+
+    except ValueError as e:
+        raise HTTPException(
+            status_code=500, 
+            detail="No available chatbots found in LiteLLM config file.",
+        ) from e
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=str(e),
+        )

--- a/src/api/chatbot/deletethread.py
+++ b/src/api/chatbot/deletethread.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request, Depends
-from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
+from fastapi import APIRouter, HTTPException, Depends
 
 from src.services.service_factory import Authenticator, AuthRequired, auth_dependency, get_thread_storage
 from src.core.logging_setup import configure_logging
@@ -22,20 +21,25 @@ async def delete_thread(
 
     if not thread_id:
         raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_CONTENT,
+            status_code=422,
             detail="Thread ID not found. Please provide thread_id in the query parameters.",
         )
 
     if not auth.vault_url:
-        raise HTTPException(status_code=503, detail="Vault URL not found. Please provide a non-empty vault URL in the headers, of type String.")
+        raise HTTPException(
+            status_code=422, 
+            detail="Vault URL not found. Please provide a non-empty vault URL in the headers, of type String.")
 
     Storage = await get_thread_storage(vault_url=auth.vault_url)
 
-    ok = await Storage.delete_thread(thread_id)
-
-    if ok:
-        logger.info("Deleted thread from storage", extra={"thread_id": thread_id, "user_id": auth.username})
-        return {"ok": ok, "body": "Successfully removed thread from history."}
-    else:
-        logger.warning("Failed to delete thread from storage", extra={"thread_id": thread_id, "user_id": auth.username})
-        return {"ok": ok, "body": f"Failed to remove thread from storage: {thread_id}"}
+    try:
+        await Storage.delete_thread(thread_id)
+        logger.info("Deleted thread from storage", 
+                    extra={"thread_id": thread_id, "user_id": auth.username})
+        return {"Successfully removed thread from storage."}
+    except:
+        logger.warning("Failed to delete thread from storage", 
+                       extra={"thread_id": thread_id, "user_id": auth.username})
+        raise HTTPException(
+            status_code=500, 
+            detail=f"Failed to remove thread from storage.")

--- a/src/api/chatbot/getthread.py
+++ b/src/api/chatbot/getthread.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 from typing import List, Dict
 
-from fastapi import APIRouter, HTTPException, Request, Query, Depends
-from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
+from fastapi import APIRouter, HTTPException, Query, Depends
 
 from src.services.service_factory import Authenticator, AuthRequired, auth_dependency, get_thread_storage
 from src.services.streaming.stream_variants import StreamVariant, is_prompt, SVStreamEnd, from_sv_to_json
@@ -29,7 +28,6 @@ def _post_process(v: List[StreamVariant]) -> List[StreamVariant]:
 
 @router.get("/getthread", dependencies=[AuthRequired])
 async def get_thread(
-    request: Request, 
     thread_id: str | None = Query(None),
     Auth: Authenticator = Depends(auth_dependency),
 ):
@@ -42,17 +40,23 @@ async def get_thread(
     """
     if not thread_id:
         raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_CONTENT,
+            status_code=422,
             detail="Thread ID not found. Please provide thread_id in the query parameters.",
         )
 
     if not Auth.vault_url:
-        raise HTTPException(status_code=503, detail="Vault URL not found. Please provide a non-empty vault URL in the headers, of type String.")
+        raise HTTPException(
+            status_code=422, 
+            detail="Vault URL not found. Please provide a non-empty vault URL in the headers, of type String."
+        )
 
     logger = configure_logging(__name__, thread_id=thread_id, user_id=Auth.username)
 
-    # Thread storage 
-    Storage = await get_thread_storage(vault_url=Auth.vault_url)
+    try:
+        # Thread storage 
+        Storage = await get_thread_storage(vault_url=Auth.vault_url)
+    except:
+        raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     try:
         await prepare_for_stream(

--- a/src/api/chatbot/heartbeat.py
+++ b/src/api/chatbot/heartbeat.py
@@ -7,4 +7,4 @@ router = APIRouter()
 @router.get("/heartbeat", dependencies=[AuthRequired])
 async def heartbeat():
     # Simple liveness probe
-    return {"ok": True}
+    return {"status": "ok"}

--- a/src/api/chatbot/stop.py
+++ b/src/api/chatbot/stop.py
@@ -29,7 +29,6 @@ async def stop_get(
     logger.debug("Initiated stop request", extra={"thread_id": thread_id})
 
     if ok:
-        return {"ok": ok, "body": "Conversation stopped."}
+        return {"Conversation stopped."}
     else:
-        return {"ok": True, "body": "Conversation with given thread-id was never registered."}
-        # raise ValueError(f"Conversation with given thread ID not found: {thread_id}")
+        raise HTTPException(status_code=500, detail="Conversation with given thread-id not found.")

--- a/src/api/chatbot/streamresponse.py
+++ b/src/api/chatbot/streamresponse.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from fastapi import APIRouter, Request, Query, HTTPException, Depends
 from starlette.responses import StreamingResponse
-from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT, HTTP_503_SERVICE_UNAVAILABLE
 
 from src.core.logging_setup import configure_logging
 from src.core.available_chatbots import default_chatbot
@@ -71,7 +70,7 @@ async def streamresponse(
     user_input = input or None
     if user_input is None:
         raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_CONTENT, 
+            status_code=422, 
             detail="Input not found. Please provide a non-empty input in the query parameters or the headers, of type String."
             )
 
@@ -82,12 +81,15 @@ async def streamresponse(
 
     if not Auth.vault_url:
         raise HTTPException(
-            status_code=HTTP_422_UNPROCESSABLE_CONTENT,
+            status_code=422,
             detail="Vault URL not found. Please provide a non-empty vault URL in the headers, of type String.",
         )
     
-    # Get thread storage
-    Storage = await get_thread_storage(vault_url=Auth.vault_url, user_name=user_name, thread_id=thread_id)
+    try:
+        # Get thread storage
+        Storage = await get_thread_storage(vault_url=Auth.vault_url, user_name=user_name, thread_id=thread_id)
+    except:
+        raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     system_prompt = get_entire_prompt(user_name, thread_id, model_name)
 

--- a/src/services/storage/helpers.py
+++ b/src/services/storage/helpers.py
@@ -133,20 +133,8 @@ async def get_database(
         """
         mongodb_uri = await get_mongodb_uri(vault_url)
 
-        try:
-            client = AsyncMongoClient(mongodb_uri)
-            return client[MONGODB_DATABASE_NAME]
-        except Exception:
-            # Rust-style fallback: strip query options and retry once
-            if "?" in mongodb_uri:
-                stripped = mongodb_uri.rsplit("?", 1)[0]
-                try:
-                    client = AsyncMongoClient(stripped)
-                    return client[MONGODB_DATABASE_NAME]
-                except Exception:
-                    pass
-            raise HTTPException(status_code=503, detail="Failed to connect to MongoDB")
-
+        client = AsyncMongoClient(mongodb_uri)
+        return client[MONGODB_DATABASE_NAME]
 
 # ──────────────────── Search threads ──────────────────────────────
 

--- a/src/services/storage/mongodb_storage.py
+++ b/src/services/storage/mongodb_storage.py
@@ -122,35 +122,21 @@ class ThreadStorage():
         self,
         thread_id: str,
         topic: str
-    ) -> bool:
-        try:
-            logger = configure_logging(__name__, thread_id=thread_id)
-            coll = self.db[MONGODB_COLLECTION_NAME]
-            update_op = { '$set' :  { 'topic' : topic } }
-            await coll.update_one({"thread_id": thread_id}, update_op)
-            logger.info("Updated topic in MongoDB", extra={"thread_id": thread_id})
-            return True
-        except:
-            logger = configure_logging(__name__, thread_id=thread_id)
-            logger.exception("Failed to update topic in MongoDB", extra={"thread_id": thread_id})
-            return False
-        
+    ):
+        logger = configure_logging(__name__, thread_id=thread_id)
+        coll = self.db[MONGODB_COLLECTION_NAME]
+        update_op = { '$set' :  { 'topic' : topic } }
+        await coll.update_one({"thread_id": thread_id}, update_op)
+        logger.info("Updated topic in MongoDB", extra={"thread_id": thread_id})
+
 
     async def delete_thread(
         self,
         thread_id: str,
-    ) -> bool:
-        try:
-            logger = configure_logging(__name__, thread_id=thread_id)
-            coll = self.db[MONGODB_COLLECTION_NAME]
-            await coll.delete_one({"thread_id": thread_id})
-            #TODO check the return
-            logger.info("Deleted thread in MongoDB", extra={"thread_id": thread_id})
-            return True
-        except:
-            logger = configure_logging(__name__, thread_id=thread_id)
-            logger.exception("Failed to delete thread in MongoDB", extra={"thread_id": thread_id})
-            return False
+    ):
+        coll = self.db[MONGODB_COLLECTION_NAME]
+        await coll.delete_one({"thread_id": thread_id})
+        
 
     async def query_by_topic(
         self,

--- a/tests/api_integration_tests/test_auth.py
+++ b/tests/api_integration_tests/test_auth.py
@@ -105,4 +105,4 @@ async def test_auth_success_200(client):
                 headers={"Authorization": "Bearer good", "x-freva-rest-url": "http://rest.example"},
             )
             assert r.status_code == 200
-            assert r.json() == {"ok": True}
+            assert r.json() == {'status': 'ok'}

--- a/tests/api_integration_tests/test_routes_auth_matrix.py
+++ b/tests/api_integration_tests/test_routes_auth_matrix.py
@@ -12,6 +12,7 @@ async def test_all_get_routes_require_auth(client):
             r = await client.get(ep)
             assert r.status_code == 401, f"{ep} should be protected (missing headers)"
 
+
 @pytest.mark.asyncio
 async def test_routes_succeed_with_auth_and_username_injection( 
     stub_resp, 
@@ -62,5 +63,5 @@ async def test_routes_succeed_with_auth_and_username_injection(
             # 5) /stop 
             r = await client.get("/api/chatbot/stop", params={"thread_id": "t-123"}, headers=GOOD_HEADERS)
             assert r.status_code == 200
-            assert r.json().get("ok") is True
+            assert r.json() == ["Conversation stopped."]
 


### PR DESCRIPTION
This PR revises chatbot endpoints so bad inputs and storage outages return predictable HTTP errors instead of leaking exceptions or partial responses.

**Changes**

- Validate required params and vault headers with explicit 422 responses across chatbot routes (getthread, getuserthreads, searchthreads, setthreadtopic, deletethread, streamresponse).
- Wrap MongoDB storage creation and CRUD calls in try/except to emit 503 on connection failure and 500 on storage errors instead of silent fallbacks.
- [available_chatbots.py](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.71-darwin-arm64/webview/#): add structured error handling for missing/invalid LiteLLM config, propagate YAML/Value errors, and remove unused request dependency.
- Simplify storage helper client creation (let connection errors surface) and remove unused return booleans in MongoDB storage mutations.
- Align response shapes and tests (e.g., heartbeat/stop) with the tightened contract.