### PR TITLE
Arm64 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   freva-gpt-backend:
-    platform: linux/amd64 # We need this, otherwise it defaults to arm64 base image and has mismatch for miniforge installer when built on mac
     image: localhost/freva-gpt-backend-${FREVAGPT_INSTANCE_NAME:?Instance name must be set in the .env file to differentiate between instances}
     build:
       context: .
@@ -17,7 +16,6 @@ services:
     networks:
       - freva-gpt
   rag:
-    platform: linux/amd64
     image: localhost/rag-server-${FREVAGPT_INSTANCE_NAME}
     build:
       context: .
@@ -34,7 +32,6 @@ services:
     networks:
       - freva-gpt
   code:
-    platform: linux/amd64
     image: localhost/code-server-${FREVAGPT_INSTANCE_NAME}
     build:
       context: .
@@ -52,7 +49,6 @@ services:
     networks:
       - freva-gpt
   litellm:
-    platform: linux/amd64
     image: ghcr.io/berriai/litellm:main-stable
     hostname: litellm-instance-${FREVAGPT_INSTANCE_NAME}
     volumes:

--- a/docker/code-server/Dockerfile
+++ b/docker/code-server/Dockerfile
@@ -6,7 +6,9 @@ FROM fedora:latest
 # ---------------------
 
 # Install necessary dependencies for miniconda
-RUN dnf install -y curl bzip2 awk git
+RUN dnf install -y curl bzip2 awk git \
+    gcc gcc-c++ make python3-devel \
+    && dnf clean all
 
 RUN mkdir /app
 

--- a/docker/code-server/Dockerfile
+++ b/docker/code-server/Dockerfile
@@ -15,9 +15,17 @@ RUN mkdir /app
 # -------------------
 
 # Download and install Miniconda (Miniforge)
-RUN curl -Lo /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
-    bash /tmp/miniforge.sh -b -p /opt/conda && \
-    rm /tmp/miniforge.sh
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) MINIFORGE_ARCH="x86_64" ;; \
+      arm64) MINIFORGE_ARCH="aarch64" ;; \
+      *) echo "Unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/miniforge.sh \
+      "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${MINIFORGE_ARCH}.sh"; \
+    bash /tmp/miniforge.sh -b -p /opt/conda; \
+    rm -f /tmp/miniforge.sh
 
 ENV PATH="/opt/conda/bin:$PATH"
 

--- a/docker/freva-gpt-backend/Dockerfile
+++ b/docker/freva-gpt-backend/Dockerfile
@@ -10,16 +10,22 @@ RUN dnf install -y curl bzip2 awk git
 
 RUN mkdir /app
 
-
-
 # -------------------
 # Conda setup
 # -------------------
 
 # Download and install Miniconda (Miniforge)
-RUN curl -Lo /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
-    bash /tmp/miniforge.sh -b -p /opt/conda && \
-    rm /tmp/miniforge.sh
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) MINIFORGE_ARCH="x86_64" ;; \
+      arm64) MINIFORGE_ARCH="aarch64" ;; \
+      *) echo "Unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/miniforge.sh \
+      "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${MINIFORGE_ARCH}.sh"; \
+    bash /tmp/miniforge.sh -b -p /opt/conda; \
+    rm -f /tmp/miniforge.sh
 
 ENV PATH="/opt/conda/bin:$PATH"
 

--- a/docker/ollama/Dockerfile
+++ b/docker/ollama/Dockerfile
@@ -1,4 +1,4 @@
-FROM ollama/ollama:0.13.1
+FROM ollama/ollama:0.15.2
 
 # Start Ollama server in background and wait for it to become ready
 RUN nohup ollama serve > /tmp/ollama.log 2>&1 & \

--- a/docker/rag-server/Dockerfile
+++ b/docker/rag-server/Dockerfile
@@ -15,9 +15,17 @@ RUN mkdir /app
 # -------------------
 
 # Download and install Miniconda (Miniforge)
-RUN curl -Lo /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
-    bash /tmp/miniforge.sh -b -p /opt/conda && \
-    rm /tmp/miniforge.sh
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) MINIFORGE_ARCH="x86_64" ;; \
+      arm64) MINIFORGE_ARCH="aarch64" ;; \
+      *) echo "Unsupported arch: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/miniforge.sh \
+      "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-${MINIFORGE_ARCH}.sh"; \
+    bash /tmp/miniforge.sh -b -p /opt/conda; \
+    rm -f /tmp/miniforge.sh
 
 ENV PATH="/opt/conda/bin:$PATH"
 

--- a/src/core/logging_setup.py
+++ b/src/core/logging_setup.py
@@ -142,6 +142,10 @@ def configure_logging(
         if handler not in logger.handlers:
             logger.addHandler(handler)
 
+    logging.getLogger("fakeredis").setLevel(logging.WARNING)
+    logging.getLogger("docket").setLevel(logging.WARNING)
+    logging.getLogger("pymongo").setLevel(logging.WARNING)
+
     return logging.LoggerAdapter(logger, {"thread_id": thread_id or "-", "user_id": user_id or "-"})
 
 


### PR DESCRIPTION
This PR adds support for ARM64, in order to make sure the server can run on different architectures. It also updates Ollama image version and quiets noisy third-party logs.

**ARM64 Support:**
- Enable native arm64 builds: remove forced platform: linux/amd64 overrides in [docker-compose.yml](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.71-darwin-arm64/webview/#) and make all Miniforge installs architecture-aware (docker/*/Dockerfile).
- Add compiler toolchain (gcc, g++, make, python3-devel) to the code-server image to build pip/uv packages with C extensions (docker/code-server/Dockerfile).

**Misc:**
- Update Ollama base image to 0.15.2 for latest fixes/features (docker/ollama/Dockerfile).
- Quiet noisy third-party logs by setting fakeredis, docket, and pymongo to WARNING ([logging_setup.py](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.71-darwin-arm64/webview/#)).