### PR TITLE
Bugfix for missing default value

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -81,6 +81,7 @@ services:
     hostname: mongodb
     ports:
       - "27016:27017"
+    command: --quiet --logpath /dev/null 
 
 networks:
   freva-gpt:

--- a/src/app.py
+++ b/src/app.py
@@ -15,6 +15,7 @@ from src.core.runtime_checks import run_startup_checks
 from src.services.streaming.active_conversations import cleanup_idle
 
 settings = get_settings()
+logger = configure_logging(__name__)
 
 # ──────────────────────────────────────────────────────────────────────────────
 # FastAPI app (skeleton)
@@ -33,12 +34,12 @@ async def lifespan(app: FastAPI):
                 # Storage is not needed here, conversation must have been saved when it was last used
                 evicted = await cleanup_idle(max_idle=timedelta(days=1))
                 if evicted:
-                    print("Evicted idle > 1 day:", evicted)
+                    logger.info("Evicted idle > 1 day:", evicted)
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 # Don’t crash the task; log and continue
-                print("Daily cleanup failed:", e)
+                logger.warning("Daily cleanup failed:", e)
                 
     # Launch background task
     app.state.periodic_cleanup = asyncio.create_task(periodic_cleanup_task())

--- a/src/services/streaming/active_conversations.py
+++ b/src/services/streaming/active_conversations.py
@@ -293,7 +293,7 @@ async def cancel_tool_tasks(thread_id: str) -> None:
 
 async def cleanup_idle(
     max_idle: timedelta,
-    Storage: Optional[ThreadStorage]
+    Storage: Optional[ThreadStorage] = None,
 ) -> list[str]:  # thread_ids evicted
     """
     Remove conversations that have been idle longer than MAX_IDLE.


### PR DESCRIPTION
This PR fixes a bug that caused the background cleanup to crash when called without a storage argument; logs from MongoDB were noisy and hard to filter during development.

- Fix: add a safe default (None) for the optional Storage parameter in cleanup_idle so callers no longer need to supply it explicitly ([active_conversations.py](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.74-darwin-arm64/webview/#)).
- Switch the daily idle-cleanup background task to use the app logger, logging both evictions and failures with proper levels ([app.py](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.74-darwin-arm64/webview/#)).

**Additional changes:**
- DX/Noise reduction: silence local MongoDB container logs in dev by running it with --quiet --logpath /dev/null ([docker-compose.dev.yml](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.74-darwin-arm64/webview/#)).