### PR TITLE
Ollama GPU usage fix and LiteLLM config update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,13 +61,8 @@ services:
     hostname: ollama-instance-${FREVAGPT_INSTANCE_NAME}
     networks:
       - freva-gpt
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
+    devices:
+      - nvidia.com/gpu=all
 
 networks:
   freva-gpt:

--- a/litellm_config.yaml
+++ b/litellm_config.yaml
@@ -10,13 +10,13 @@ model_list:
       api_key: "os.environ/FREVAGPT_OPENAI_API_KEY" 
   - model_name: "ministral-3:14b"
     litellm_params:
-      model: "ollama/ministral-3:14b"
+      model: "ollama_chat/ministral-3:14b"
       api_base: "http://ollama:11434"
     model_info:
       supports_function_calling: true
   - model_name: "qwen2.5:3b"
     litellm_params:
-      model: "ollama/qwen2.5:3b"
+      model: "ollama_chat/qwen2.5:3b"
       api_base: "http://ollama:11434" 
     model_info:
       supports_function_calling: true


### PR DESCRIPTION
**Motivation / Context**

- Ollama service failed to schedule GPUs when running with plain docker compose (the previous deploy.resources.reservations.devices block is swarm-only).
- LiteLLM config needed to point to the chat-capable Ollama endpoints so function-calling works with the local models.

**Changes**

- Switch GPU allocation for the ollama service to devices: ["nvidia.com/gpu=all"].
- Update LiteLLM entries for ministral-3:14b and [qwen2.5:3b](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#) to use the ollama_chat/... model ids while keeping the same Ollama base URL.