### PR TITLE
Mongodb optimization

### DIFF
--- a/src/services/storage/helpers.py
+++ b/src/services/storage/helpers.py
@@ -133,7 +133,7 @@ async def get_database(
         """
         mongodb_uri = await get_mongodb_uri(vault_url)
 
-        client = AsyncMongoClient(mongodb_uri)
+        client = AsyncMongoClient(mongodb_uri, connectTimeoutMS=30000)
         return client[MONGODB_DATABASE_NAME]
 
 # ──────────────────── Search threads ──────────────────────────────

--- a/src/services/storage/mongodb_storage.py
+++ b/src/services/storage/mongodb_storage.py
@@ -32,6 +32,7 @@ class ThreadStorage():
             self.db = AsyncMongoClient(settings.MONGODB_URI_DEV)[MONGODB_DATABASE_NAME]
         else:
             self.db = await get_database(self.vault_url)
+        await self.db[MONGODB_COLLECTION_NAME].create_index([("thread_id", 1)])
         return self
 
 

--- a/src/services/storage/mongodb_storage.py
+++ b/src/services/storage/mongodb_storage.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Tuple, Optional, Any
 from datetime import datetime, timezone
 import re
 
+import pymongo
 from pymongo import AsyncMongoClient
 
 from .helpers import Thread, get_database, summarize_topic, Variant, VARIANT_FIELD
@@ -32,7 +33,11 @@ class ThreadStorage():
             self.db = AsyncMongoClient(settings.MONGODB_URI_DEV)[MONGODB_DATABASE_NAME]
         else:
             self.db = await get_database(self.vault_url)
-        await self.db[MONGODB_COLLECTION_NAME].create_index([("thread_id", 1)])
+
+        coll = self.db[MONGODB_COLLECTION_NAME]
+        await coll.create_index("thread_id", unique=True)
+        await coll.create_index([("user_id", pymongo.ASCENDING), ("date", pymongo.DESCENDING)])
+        
         return self
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,9 @@ class DummyCollection:
             return len(self.storage)
         return sum(1 for doc in self.storage.values() if doc.get("user_id") == user_id)
 
+    async def create_index(self, ind):
+        pass
+
 
 class DummyDB:
     def __init__(self):


### PR DESCRIPTION
Motivation: prevent duplicate thread ids, speed up lookups, and reduce connection flakiness during startup

**Changes:** 
- Add unique index on thread_id plus compound index on (user_id, date) in [mongodb_storage.py](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
- Bump Mongo client connect timeout to 30s in [helpers.py](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#)
- Stub create_index in [conftest.py](https://file+.vscode-resource.vscode-cdn.net/Users/gizem/.vscode/extensions/openai.chatgpt-0.4.76-darwin-arm64/webview/#) to fix the tests
