### PR TITLE
Docker update

### DIFF
--- a/docker/code-server/Dockerfile
+++ b/docker/code-server/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf install -y curl bzip2 awk git \
     && dnf clean all
 
 RUN mkdir /app
+WORKDIR /app
 
 # -------------------
 # Conda setup
@@ -36,23 +37,24 @@ RUN conda create --name env "python>=3.11.10,<3.12"
 RUN conda init bash
 RUN echo "conda activate env" >> ~/.bashrc
 
-WORKDIR /app
-
 # -----------------
 # uv and deps
 # -----------------
 
-RUN pip install uv
+# Install uv into the env 
+RUN conda run -n env python -m pip install --no-cache-dir uv
 
 COPY docker/code-server/pyproject.toml /app/pyproject.toml
 
-# Export from pyproject and install into the current interpreter (Conda)
-# --system is required when mutating a non-venv interpreter
-RUN source activate env && uv export --format requirements-txt \
-    | uv pip install --no-cache-dir --system --python "$(python -c 'import sys; print(sys.executable)')" -r -
+# Export requirements from pyproject.toml into a file
+RUN conda run -n env uv export --format requirements-txt --no-hashes -o /tmp/requirements.txt
+# Install exactly those requirements into the env's interpreter
+RUN conda run -n env uv pip install --no-cache-dir --system \
+    --python "/opt/conda/envs/env/bin/python" \
+    -r /tmp/requirements.txt
 
 # Install Python deps via uv (this replaces `pip install ...`)
-RUN source activate env && uv pip install \
+RUN conda run -n env uv pip install \
     freva-client dill numpy matplotlib pandas xarray xesmf scipy netcdf4 cartopy contourpy \
     geopy aiohttp requests scikit-learn geopandas healpy easygems astropy 
 
@@ -60,10 +62,8 @@ RUN source activate env && uv pip install \
 RUN conda install --yes -c conda-forge -n env pytorch
 
 # Python env paths
-ENV PYTHONUSERBASE /opt/conda/envs/env
-ENV PYTHONPATH=/opt/conda/envs/env/lib/python3.11/site-packages
-ENV PATH /opt/conda/envs/env/bin/:$PATH
-ENV LD_LIBRARY_PATH /opt/conda/envs/env/lib/:$PATH
+ENV PATH="/opt/conda/envs/env/bin/:$PATH"
+ENV LD_LIBRARY_PATH="/opt/conda/envs/env/lib/:${LD_LIBRARY_PATH}"
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
 EXPOSE 8051

--- a/docker/code-server/Dockerfile
+++ b/docker/code-server/Dockerfile
@@ -61,6 +61,10 @@ RUN conda run -n env uv pip install \
 # These libraries cannot be installed by uv, so we use conda.
 RUN conda install --yes -c conda-forge -n env pytorch
 
+# # Install pytorch with CUDA wheels
+# RUN conda run -n env python -m pip install --no-cache-dir \
+#     torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+
 # Python env paths
 ENV PATH="/opt/conda/envs/env/bin/:$PATH"
 ENV LD_LIBRARY_PATH="/opt/conda/envs/env/lib/:${LD_LIBRARY_PATH}"

--- a/docker/freva-gpt-backend/Dockerfile
+++ b/docker/freva-gpt-backend/Dockerfile
@@ -9,6 +9,7 @@ FROM fedora:latest
 RUN dnf install -y curl bzip2 awk git
 
 RUN mkdir /app
+WORKDIR /app
 
 # -------------------
 # Conda setup
@@ -34,21 +35,21 @@ RUN conda create --name env "python>=3.11.10,<3.12"
 RUN conda init bash
 RUN echo "conda activate env" >> ~/.bashrc
 
-WORKDIR /app
-
 # -----------------
 # uv and deps
 # -----------------
 
-# Uv is a much faster package manager and installer, we'll use it over conda where possible to cut time.
-RUN pip install uv
+# Install uv into the env 
+RUN conda run -n env python -m pip install --no-cache-dir uv
 
 COPY pyproject.toml /app/pyproject.toml
 
-# Export from pyproject and install into the current interpreter (Conda)
-# --system is required when mutating a non-venv interpreter
-RUN source activate env && uv export --format requirements-txt \
-    | uv pip install --no-cache-dir --system --python "$(python -c 'import sys; print(sys.executable)')" -r -
+# Export requirements from pyproject.toml into a file
+RUN conda run -n env uv export --format requirements-txt --no-hashes -o /tmp/requirements.txt
+# Install exactly those requirements into the env's interpreter
+RUN conda run -n env uv pip install --no-cache-dir --system \
+    --python "/opt/conda/envs/env/bin/python" \
+    -r /tmp/requirements.txt
 
 # -------------------------
 # Config + source
@@ -58,10 +59,9 @@ RUN source activate env && uv export --format requirements-txt \
 COPY litellm_config.yaml /app/litellm_config.yaml
 
 # Python env paths
-ENV PYTHONUSERBASE /opt/conda/envs/env
-ENV PYTHONPATH=/opt/conda/envs/env/lib/python3.11/site-packages
-ENV PATH /opt/conda/envs/env/bin/:$PATH
-ENV LD_LIBRARY_PATH /opt/conda/envs/env/lib/:$PATH
+ENV PATH="/opt/conda/envs/env/bin/:$PATH"
+ENV LD_LIBRARY_PATH="/opt/conda/envs/env/lib/:${LD_LIBRARY_PATH}"
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
 # Copy source code
 COPY src /app/src

--- a/docker/rag-server/Dockerfile
+++ b/docker/rag-server/Dockerfile
@@ -9,6 +9,7 @@ FROM fedora:latest
 RUN dnf install -y curl bzip2 awk git
 
 RUN mkdir /app
+WORKDIR /app
 
 # -------------------
 # Conda setup
@@ -34,26 +35,25 @@ RUN conda create --name env "python>=3.11.10,<3.12"
 RUN conda init bash
 RUN echo "conda activate env" >> ~/.bashrc
 
-WORKDIR /app
-
 # -----------------
 # uv and deps
 # -----------------
 
-RUN pip install uv
+# Install uv into the env 
+RUN conda run -n env python -m pip install --no-cache-dir uv
 
 COPY docker/rag-server/pyproject.toml /app/pyproject.toml
 
-# Export from pyproject and install into the current interpreter (Conda)
-# --system is required when mutating a non-venv interpreter
-RUN source activate env && uv export --format requirements-txt \
-    | uv pip install --no-cache-dir --system --python "$(python -c 'import sys; print(sys.executable)')" -r -
+# Export requirements from pyproject.toml into a file
+RUN conda run -n env uv export --format requirements-txt --no-hashes -o /tmp/requirements.txt
+# Install exactly those requirements into the env's interpreter
+RUN conda run -n env uv pip install --no-cache-dir --system \
+    --python "/opt/conda/envs/env/bin/python" \
+    -r /tmp/requirements.txt
 
 # Python env paths
-ENV PYTHONUSERBASE /opt/conda/envs/env
-ENV PYTHONPATH=/opt/conda/envs/env/lib/python3.11/site-packages
-ENV PATH /opt/conda/envs/env/bin/:$PATH
-ENV LD_LIBRARY_PATH /opt/conda/envs/env/lib/:$PATH
+ENV PATH="/opt/conda/envs/env/bin/:$PATH"
+ENV LD_LIBRARY_PATH="/opt/conda/envs/env/lib/:${LD_LIBRARY_PATH}"
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
 EXPOSE 8050


### PR DESCRIPTION
- Installs uv inside the conda env via conda run (instead of host pip), exports deps to a temp requirements file, and installs them back into the env interpreter for deterministic, env-scoped builds.
- Cleans environment variables: rely on env bin/lib on PATH/LD_LIBRARY_PATH, drop PYTHONUSERBASE/PYTHONPATH, and add PYTHONDONTWRITEBYTECODE + PYTHONUNBUFFERED where missing.
- Adds a commented example for installing PyTorch CUDA wheels for future GPU-enabled builds.
