### PR TITLE
Run MCP servers with uvicorn entrypoints

### DIFF
--- a/docker/code-server/Dockerfile
+++ b/docker/code-server/Dockerfile
@@ -56,7 +56,7 @@ RUN conda run -n env uv pip install --no-cache-dir --system \
 # Install Python deps via uv (this replaces `pip install ...`)
 RUN conda run -n env uv pip install \
     freva-client dill numpy matplotlib pandas xarray xesmf scipy netcdf4 cartopy contourpy \
-    geopy aiohttp requests scikit-learn geopandas healpy easygems astropy tzdata
+    geopy aiohttp requests scikit-learn geopandas healpy easygems astropy tzdata pytz
 
 # These libraries cannot be installed by uv, so we use conda.
 RUN conda install --yes -c conda-forge -n env pytorch
@@ -70,9 +70,12 @@ ENV PATH="/opt/conda/envs/env/bin/:$PATH"
 ENV LD_LIBRARY_PATH="/opt/conda/envs/env/lib/:${LD_LIBRARY_PATH}"
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
-EXPOSE 8051
+EXPOSE ${FREVAGPT_MCP_PORT:-8051}
 
 COPY src /app/src
 
 # Launch CI server
-CMD ["python","-m","src.tools.code.server"]
+CMD uvicorn src.tools.code.server:app \
+    --host ${FREVAGPT_MCP_HOST:-0.0.0.0}\
+    --port ${FREVAGPT_MCP_PORT:-8051} \
+    --proxy-headers

--- a/docker/rag-server/Dockerfile
+++ b/docker/rag-server/Dockerfile
@@ -56,9 +56,12 @@ ENV PATH="/opt/conda/envs/env/bin/:$PATH"
 ENV LD_LIBRARY_PATH="/opt/conda/envs/env/lib/:${LD_LIBRARY_PATH}"
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
 
-EXPOSE 8050
+EXPOSE ${FREVAGPT_MCP_PORT:-8050}
 
 COPY src /app/src
 
-# Launch RAG server
-CMD ["python","-m","src.tools.rag.server"]
+# Launch CI server
+CMD uvicorn src.tools.rag.server:app \
+    --host ${FREVAGPT_MCP_HOST:-0.0.0.0}\
+    --port ${FREVAGPT_MCP_PORT:-8050} \
+    --proxy-headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ class DummyCollection:
             return len(self.storage)
         return sum(1 for doc in self.storage.values() if doc.get("user_id") == user_id)
 
-    async def create_index(self, ind):
+    async def create_index(self, ind, unique=False):
         pass
 
 


### PR DESCRIPTION
**Changes:**
- Switch both MCP services (code interpreter and RAG) to module-level uvicorn apps so containers launch via uvicorn and support configurable host/port/path env vars.
- Update Dockerfiles to expose dynamic ports, run the new uvicorn entrypoints, and add missing pytz dependency to code server.

**Test fix:**
- Align test MongoDB stub with production signature by allowing the optional unique flag on create_index.