### PR TITLE
Bugfix: /getthread initializing stream creates undesired conflict

### DIFF
--- a/src/api/chatbot/getthread.py
+++ b/src/api/chatbot/getthread.py
@@ -22,7 +22,7 @@ def _post_process(v: List[StreamVariant]) -> List[StreamVariant]:
             is_last = (i == len(items) - 1)
             if (not is_last) or ("unexpected manner" in (getattr(v, "message", "") or "").lower()):
                 continue
-        cleaned.append(from_sv_to_json(v))
+        cleaned.append(v)
     return cleaned
 
 
@@ -85,14 +85,7 @@ async def get_thread(
         raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     try:
-        await prepare_for_stream(
-            thread_id=thread_id, 
-            user_id=Auth.username,
-            Auth=Auth,
-            Storage=Storage,
-            read_history=True,
-            logger=logger,
-        )
+        content = await Storage.read_thread(thread_id=thread_id)
     except FileNotFoundError:
         logger.exception("Thread not found.", extra={"thread_id": thread_id})
         raise HTTPException(status_code=404, detail="Thread not found.")
@@ -100,10 +93,9 @@ async def get_thread(
         logger.exception(f"Error reading thread file: {e}", extra={"thread_id": thread_id})
         raise HTTPException(status_code=500, detail=f"Error reading thread file: {e}")
         
-    content = await get_conv_messages(thread_id)
-
     content = _post_process(content)
 
-    logger.info("Fetched thread content.", extra={"thread_id": thread_id, "user_id": Auth.username})
+    logger.info("Fetched thread content.", extra={"thread_id": thread_id, 
+                                                  "user_id": Auth.username})
 
     return content

--- a/tests/api_integration_tests/test_getthread.py
+++ b/tests/api_integration_tests/test_getthread.py
@@ -38,17 +38,18 @@ async def test_getthread_returns_500_when_history_invalid(
     client,
     patch_db,
     patch_mongo_uri,
-    patch_mcp_manager,
     GOOD_HEADERS,
     monkeypatch,
 ):
     async def _raise_value_error(*args, **kwargs):
         raise ValueError("broken history")
 
+    import src.services.storage.mongodb_storage as mongo_store
     monkeypatch.setattr(
-        "src.api.chatbot.getthread.prepare_for_stream",
+        mongo_store.ThreadStorage,
+        "read_thread",
         _raise_value_error,
-        raising=True,
+        raising=False,
     )
 
     with stub_resp:

--- a/tests/api_integration_tests/test_routes_auth_matrix.py
+++ b/tests/api_integration_tests/test_routes_auth_matrix.py
@@ -54,7 +54,7 @@ async def test_routes_succeed_with_auth_and_username_injection(
             r = await client.get(
                 "/api/chatbot/streamresponse",
                 headers=GOOD_HEADERS,
-                params={"input": "hi there", "chatbot": "qwen2.5:3b"},
+                params={"thread_id": "t-123", "input": "hi there", "chatbot": "qwen2.5:3b"},
             )
             assert r.status_code == 200
             assert r.headers.get("content-type", "").startswith("application/x-ndjson")

--- a/tests/api_integration_tests/test_routes_params.py
+++ b/tests/api_integration_tests/test_routes_params.py
@@ -24,7 +24,6 @@ async def test_getthread_ok_with_thread_id(
     client, 
     patch_db, 
     patch_read_thread, 
-    patch_mcp_manager, 
     GOOD_HEADERS
 ):
     with  stub_resp:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,7 +188,7 @@ def patch_mongo_uri(monkeypatch):
 
 @pytest.fixture
 def patch_read_thread(monkeypatch):
-    async def _fake(thread_id: str, database):
+    async def _fake(self, thread_id: str):
         return [
             {"variant": "Prompt", "text": "user prompt should be filtered out"},
             {"variant": "User", "text": "kept"},


### PR DESCRIPTION
**Motivation**
Calling /getthread was triggering prepare_for_stream, unintentionally starting a new active stream and conflicting with any in-flight streaming for the same thread.

**Changes**

`/getthread` reads saved content via `Storage.read_thread` without invoking stream preparation. Fetching an existing thread no longer initializes streaming side effects, preventing duplicate or conflicting stream sessions.