### PR TITLE
Removed prefix-based search support

### DIFF
--- a/src/api/chatbot/searchthreads.py
+++ b/src/api/chatbot/searchthreads.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import Union, Tuple
-
 from fastapi import APIRouter, HTTPException, Depends
 
 from src.services.service_factory import Authenticator, AuthRequired, auth_dependency, get_thread_storage
-from src.services.storage.helpers import Variant, PREFIX_MAP
 from src.core.logging_setup import configure_logging
 
 router = APIRouter()
@@ -13,27 +10,23 @@ router = APIRouter()
 
 @router.get("/searchthreads", dependencies=[AuthRequired])
 async def search_threads(
-    num_threads: int,
     query: str,
+    num_threads: int = 20,
     auth: Authenticator = Depends(auth_dependency),
 ):
     """
     Search User Threads.
 
     Searches the authenticated user's conversation threads using a query
-    string. Supports topic-based search and variant-based search, depending
-    on the parsed query format.
+    string. Supports only topic-based search.
     Requires a valid authenticated user and vault-url.
 
     Parameters:
-        num_threads (int):
-            The maximum number of matching threads to return.
-        page (int):
-            The page number for pagination (reserved for paging logic).
         query (str):
-            The search query string. The query may be interpreted as:
-                - A topic search (default mode), or
-                - A variant-based search (if matching variant syntax).
+            The search query string.
+        num_threads (int):
+            The maximum number of matching threads to return. Default 
+            value is 20.
 
     Dependencies:
         auth (Authenticator): Injected authentication object containing 
@@ -85,15 +78,8 @@ async def search_threads(
     except:
         raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
-    # Decide search mode (topic vs variant)
-    mode, _query = parse_query_mode(query)
-
     try:
-        if mode == "variant":
-            variant, content = _query
-            total_num_threads, threads = await Storage.query_by_variant(auth.username, variant, content, num_threads)
-        else:
-            total_num_threads, threads = await Storage.query_by_topic(auth.username, _query, num_threads)
+        total_num_threads, threads = await Storage.query_by_topic(auth.username, query, num_threads)
     except Exception:
         raise HTTPException(status_code=500, detail="Failed to query threads.")
 
@@ -110,26 +96,3 @@ async def search_threads(
         ], 
         total_num_threads
     ]
-
-
-def parse_query_mode(query: str) -> Union[str, Tuple[Variant, str]]:
-    """
-    Returns:
-      - query string OR
-      - (variant, content) if prefix is recognized
-    If prefix is unknown, sliently falls back to plain query search.
-    """
-    q = query.strip().lower() # case-insensitive search
-    if ":" not in q:
-        return "topic", q
-
-    prefix, content = q.split(":", 1)
-    prefix = prefix.strip()
-    content = content.strip()
-
-    variant = PREFIX_MAP.get(prefix)
-    if variant:
-        return "variant", (variant, content)
-
-    # unknown prefix falls back to topic query, not error
-    return "topic", q

--- a/src/api/static.py
+++ b/src/api/static.py
@@ -48,10 +48,7 @@ def help(
             "point in an existing thread. This allows you to explore a "\
             "different direction without losing the original conversation.",
         "searchthreads": "Search your conversations by keywords to quickly "\
-            "find specific topics. You can also use prefixes like 'user:', "\
-            "'ai:', or 'code:' to search only within your messages, "\
-            "FrevaGPT's replies, or code blocks. This helps you quickly "\
-            "find specific topics, questions, or messages across your threads.",
+            "find specific topics.",
         "setthreadtopic": "Rename a conversation. This helps you organize "\
             "and quickly identify your threads later.",
         "userfeedback": "Give a thumbs up or thumbs down to rate FrevaGPT's "\

--- a/src/services/storage/helpers.py
+++ b/src/services/storage/helpers.py
@@ -135,32 +135,3 @@ async def get_database(
 
         client = AsyncMongoClient(mongodb_uri, connectTimeoutMS=30000)
         return client[MONGODB_DATABASE_NAME]
-
-# ──────────────────── Search threads ──────────────────────────────
-
-Variant = Literal["User", "Assistant", "Code", "CodeOutput"]
-
-
-PREFIX_MAP: Dict[str, Variant] = {
-    # user variants
-    "user": "User", "u": "User", "input": "User", "me": "User", "question": "User",
-    "request": "User", "i": "User", "benutzer": "User", "eingabe": "User",
-    # assistant variants
-    "ai": "Assistant", "a": "Assistant", "assistant": "Assistant",
-    "frevagpt": "Assistant", "freva-gpt": "Assistant", "freva_gpt": "Assistant",
-    "answer": "Assistant", "ki": "Assistant", "assistent": "Assistant",
-    "computer": "Assistant",
-    # code input variants
-    "code_input": "Code", "ci": "Code", "code": "Code", "codeinput": "Code",
-    "python": "Code", "py": "Code",
-    # code output variants
-    "code_output": "CodeOutput", "co": "CodeOutput", "codeoutput": "CodeOutput",
-    "output": "CodeOutput", "ausgabe": "CodeOutput", "ergebnis": "CodeOutput",
-}
-
-VARIANT_FIELD: Dict[Variant, str] = {
-    "User": "user_text",
-    "Assistant": "assistant_text",
-    "Code": "code_input",
-    "CodeOutput": "code_output",
-}

--- a/src/services/storage/mongodb_storage.py
+++ b/src/services/storage/mongodb_storage.py
@@ -5,7 +5,7 @@ import re
 import pymongo
 from pymongo import AsyncMongoClient
 
-from .helpers import Thread, get_database, summarize_topic, Variant, VARIANT_FIELD
+from .helpers import Thread, get_database, summarize_topic
 from src.core.settings import get_settings
 from src.services.streaming.stream_variants import StreamVariant, cleanup_conversation, from_sv_to_json, from_json_to_sv
 from src.core.logging_setup import configure_logging
@@ -157,48 +157,6 @@ class ThreadStorage():
         filt = {
             "user_id": user_id,
             "topic": {"$regex": re.escape(topic), "$options": "i"},
-        }
-
-        total = await coll.count_documents(filt)
-        cursor = (
-            coll.find(filt)
-            .sort("updated_at", -1)
-            .limit(num_threads)
-        )
-        docs = await cursor.to_list(length=num_threads)
-        threads = [
-            Thread(
-                user_id=d["user_id"],
-                thread_id=d["thread_id"],
-                date=d["date"],
-                topic=d.get("topic", ""),
-                content=d.get("content", []),
-            )
-            for d in docs
-        ]
-        return total, threads
-
-
-    async def query_by_variant(
-        self,
-        user_id: str,
-        variant: Variant,
-        content: str,
-        num_threads: int,
-    ) -> Dict[str, Any]:
-        """
-        Search in a specific variant field (user/assistant/code/code_output).
-        """
-        coll = self.db[MONGODB_COLLECTION_NAME]
-
-        filt = {
-            "user_id": user_id,
-            "content": {
-                "$elemMatch": {
-                    "variant": variant,
-                    "content": {"$regex": re.escape(content), "$options": "i"},
-                }
-            },
         }
 
         total = await coll.count_documents(filt)


### PR DESCRIPTION
**Motivation:**
Simplifies thread search to a single topic-based path and removes prefix/variant filtering.
Makes num_threads optional with a default of 20 and updates the endpoint docstring accordingly.

**Changes:**

- Removed prefix parsing and variant-specific search; search_threads now always calls query_by_topic, and the helper/variant maps and MongoDB variant query path are removed.
- Pruned API help text to describe only keyword/topic search, matching the simplified behavior.
- Kept response shape intact while updating parameter defaults to reduce required inputs for common use.
