### PR TITLE
Added freva-web services to local dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -95,11 +95,81 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: secret
     hostname: mongodb
     ports:
-      - "27016:27017"
+      - "27017:27017"
     command: --quiet --logpath /dev/null 
+
+  freva-db:
+    networks:
+      - freva-gpt
+    hostname: freva-db
+    container_name: freva-db
+    image: ghcr.io/freva-org/freva-mysql:9.3.0
+    environment:
+      - ROOT_PW=T3st
+      - HOST=localhost
+      - PROJECT=freva-dev
+      - MYSQL_USER=freva
+      - MYSQL_PASSWORD=T3st
+      - MYSQL_DATABASE=frevadb
+      - MYSQL_ROOT_PASSWORD=test_password_please_ignore
+    ports:
+      - "3306:3306"
+
+  freva-vault:
+    networks:
+      - freva-gpt
+    image: ghcr.io/freva-org/freva-vault:latest
+    hostname: freva-vault
+    container_name: freva-vault
+    cap_add:
+      - IPC_LOCK
+      - SYS_NICE
+    environment:
+      - ROOT_PW=T3st
+      - KEY_FILE=/vault/file/keys
+      - VAULT_ADD_VAR_DB_DB=frevadb
+      - VAULT_ADD_VAR_DB_HOST=freva-db
+      - VAULT_ADD_VAR_DB_PASSWD=T3st
+      - VAULT_ADD_VAR_MONGO_DB=search_stats
+      - VAULT_ADD_VAR_MONGO_PASSWD=secret
+      - VAULT_ADD_VAR_MONGO_USER=mongo
+      - VAULT_ADD_VAR_MONGO_URL='mongodb://mongo:secret@freva-mongo:27017'
+
+  freva-web:
+    networks:
+      - freva-gpt
+    image: ghcr.io/freva-org/freva-web:2604.0.0
+    ports:
+      - "8000:8000"
+    container_name: freva-web
+    hostname: freva-web
+    environment:
+      - EVALUATION_SYSTEM_CONFIG_FILE=/data/evaluation_system.conf
+      - DJANGO_SUPERUSER_PASSWORD=T3st
+      - ALLOWED_HOSTS=localhost,127.0.0.1
+      - SCHEDULER_HOST=localhost
+      - REDIS_HOST=freva-cache
+      - CSRF_TRUSTED_ORIGINS=http://127.0.0.1,http://localhost
+      - FREVA_REST_URL=http://regiklim-dev.dkrz.de:7777
+      - CHAT_BOT_URL=http://freva-gpt-backend:8502
+      - ACTIVATE_CHAT_BOT=1
+      - STAC_BROWSER=1
+      - DEV_MODE=1
+      - CHAT_BOT=1
+    volumes:
+      - ./docker/freva.conf:/data/evaluation_system.conf
+
+  freva-cache:
+    networks:
+      - freva-gpt
+    image: ghcr.io/freva-org/freva-redis:latest
+    hostname: freva-cache
+    container_name: freva-cache
+
 
 networks:
   freva-gpt:
     driver: bridge
+
 # The subnet is not set to avoid conflicts with other potentially running networks on the same machine.
 # Note: Named networks by default aren't shared between different docker-compose projects, even if they have the same name, as long as they are in separate directories.

--- a/docker/freva.conf
+++ b/docker/freva.conf
@@ -1,0 +1,81 @@
+[evaluation_system]
+# Freva - Free Evaluation System Framework
+# Config File
+admins=
+project_name=freva-ces
+project_website=www.freva.dkrz.de
+
+#: The installation location of the evaluation_system, leave this empty to be set
+#: by the installation routine.
+root_dir=/tmp
+
+#: The name of the evaluation_system instance
+base_dir=${project_name}
+
+#: The location of the work direcotry, that is user specific data
+#: We are storing this in the user home at this time since it's being used as
+#:a tool-box.
+base_dir_location=/tmp/evaluation_system/work
+
+#: work directory for the SLURM scheduler
+#: when empty, the configuration will be read from User-object
+
+scheduler_input_dir=/tmp/slurm
+scheduler_output_dir=${root_dir}/share/slurm
+scheduler_system=local
+
+#: path to copy the preview to, this directory holds data, like images,
+#: for the web frontend
+preview_path=${root_dir}/share/preview
+
+#: root path of project data
+project_data=${root_dir}/data/crawl_my_data
+
+#: make scratch dir browseable for website, note escape '$' with '$$'
+scratch_dir=${base_dir_location}/$$USER
+
+#: Type of directory structure that will be used to maintain state:
+#:
+#:    local   := <home>/<base_dir>...
+#:    central := <base_dir_location>/<base_dir>/<user>/...
+#:    scratch := <base_dir_location>/<user>/<base_dir>...
+#:
+#: (no user info in local since that is included in the home directory already)
+directory_structure_type=scratch
+
+number_of_processes=6
+
+#: database path
+
+#: mySQL settings
+db.host=freva-db
+db.user=freva
+db.passwd=T3st
+db.db=frevadb
+db.port=3306
+
+
+#group for external users
+#external_group=frevaext
+
+#: Define access to the solr instance
+solr.databrowser_host=http://regiklim-dev.dkrz.de:7777
+
+#shellinabox
+#shellmachine=None
+#shellport=4200
+
+[scheduler_options]
+source=None
+partition=None
+memory=256GiB
+queue=gpu
+project=ch1187
+walltime=08:00:00
+cpus=12
+extra_options=--qos=test, --array=20
+#[scheduler_options_extern]
+#module_command=/home/dkrz/k204230/workspace//freva-dev/freva/modules/freva/1.0
+#extra_modules=None:
+#source=None
+#option_partition=None


### PR DESCRIPTION
**Changes:**

- Add Freva web stack (MySQL freva-db, Vault freva-vault, Django UI freva-web, Redis freva-cache) to docker-compose.dev.yml so local devs can spin up the full Freva + chatbot flow.
- Mount new config docker/freva.conf into freva-web to point the evaluation system at the local DB and existing Solr endpoint, with scheduler and workspace defaults prefilled.
- Expose supporting ports (3306, 8000) and switch MongoDB mapping to the default 27017:27017 to align with the vault/URL configuration.