### PR TITLE
Fixed bug with arguments sent to tool call for code replay

### DIFF
--- a/src/services/streaming/active_conversations.py
+++ b/src/services/streaming/active_conversations.py
@@ -273,7 +273,7 @@ async def _replay_code_history(thread_id: str) -> None:
             await run_tool_via_mcp(
                 mcp=mcp,
                 tool_name="code_interpreter",
-                arguments_json=json.dumps({"code": code}),
+                arguments_json=code,
                 logger=log,
             )
 


### PR DESCRIPTION
This PR fixes a bug with the format of the argument for code replay.