### PR TITLE
Implement thread ownership

### DIFF
--- a/src/api/chatbot/deletethread.py
+++ b/src/api/chatbot/deletethread.py
@@ -61,6 +61,14 @@ async def delete_thread(
     Storage = await get_thread_storage(vault_url=auth.vault_url)
 
     try:
+        user_id = await Storage.get_user_id_for_thread(thread_id)
+        # Only allow the deletion of the thread if the user is the owner of the thread
+        if user_id != auth.username:
+            raise HTTPException(
+                status_code=403,
+                detail="You are not the owner of this thread.",
+            )
+
         await Storage.delete_thread(thread_id)
         logger.info(
             "Deleted thread from storage",

--- a/src/api/chatbot/deletethread.py
+++ b/src/api/chatbot/deletethread.py
@@ -61,9 +61,9 @@ async def delete_thread(
     Storage = await get_thread_storage(vault_url=auth.vault_url)
 
     try:
-        user_id = await Storage.get_user_id_for_thread(thread_id)
+        thread_owner = await Storage.get_user_id_for_thread(thread_id)
         # Only allow the deletion of the thread if the user is the owner of the thread
-        if user_id != auth.username:
+        if thread_owner and thread_owner != auth.username:
             raise HTTPException(
                 status_code=403,
                 detail="You are not the owner of this thread.",

--- a/src/api/chatbot/editthread.py
+++ b/src/api/chatbot/editthread.py
@@ -9,14 +9,13 @@ from src.services.service_factory import (
 from src.services.streaming.stream_variants import (
     from_json_to_sv,
     from_sv_to_json,
-    SVServerHint,
-    StreamVariant,
 )
 from src.services.streaming.active_conversations import (
     new_thread_id,
     check_thread_exists,
     initialize_conversation,
 )
+from src.services.storage.mongodb_storage import update_threadid_in_content
 from src.core.logging_setup import configure_logging
 
 router = APIRouter()
@@ -191,19 +190,3 @@ async def edit_thread(
         "new_thread_id": new_id,
         "history": base_json,
     }
-
-
-def update_threadid_in_content(new_id: str, content: list[StreamVariant], logger):
-    if isinstance(content[0], SVServerHint):
-        content[0] = SVServerHint(data={"thread_id": new_id})
-        logger.info("Updated ServerHint with new thread-id.")
-    else:
-        if any(isinstance(c, SVServerHint) for c in content):
-            logger.exception("ServerHint is in unexpected position in thread content!")
-            raise ValueError("ServerHint is in unexpected position in thread content!")
-        else:
-            logger.info(
-                "ServerHint is missing in the thread content. It is inserted with the new thread-id."
-            )
-            content = [SVServerHint(data={"thread_id": new_id})] + content
-    return content

--- a/src/api/chatbot/setthreadtopic.py
+++ b/src/api/chatbot/setthreadtopic.py
@@ -72,9 +72,9 @@ async def set_thread_topic(
         raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     try:
-        user_id = await Storage.get_user_id_for_thread(thread_id)
+        thread_owner = await Storage.get_user_id_for_thread(thread_id)
         # Only allow the update of the thread topic if the user is the owner of the thread
-        if user_id != auth.username:
+        if thread_owner and thread_owner != auth.username:
             raise HTTPException(
                 status_code=403,
                 detail="You are not the owner of this thread.",

--- a/src/api/chatbot/setthreadtopic.py
+++ b/src/api/chatbot/setthreadtopic.py
@@ -72,6 +72,13 @@ async def set_thread_topic(
         raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     try:
+        user_id = await Storage.get_user_id_for_thread(thread_id)
+        # Only allow the update of the thread topic if the user is the owner of the thread
+        if user_id != auth.username:
+            raise HTTPException(
+                status_code=403,
+                detail="You are not the owner of this thread.",
+            )
         await Storage.update_thread_topic(thread_id, topic)
         logger.info(
             "Updated thread topic",

--- a/src/api/chatbot/streamresponse.py
+++ b/src/api/chatbot/streamresponse.py
@@ -168,6 +168,16 @@ async def streamresponse(
         Storage = await get_thread_storage(
             vault_url=Auth.vault_url, user_name=user_name, thread_id=thread_id
         )
+        # If the thread does not belong to this user, fork it and continue with a different thread_id
+        thread_user = await Storage.get_user_id_for_thread(thread_id)
+        if thread_user and thread_user != user_name:
+            old_thread_id = thread_id
+            thread_id = await new_thread_id()
+            logger.info(
+                f"Thread {old_thread_id} belongs to a different user ({thread_user}). Forking the thread for the current user with new thread_id: {thread_id}..."
+            )
+            await Storage.fork_thread(old_thread_id, thread_id, user_name)
+            logger = configure_logging(__name__, thread_id=thread_id, user_id=user_name)
     except Exception as e:
         logger.exception(
             "Failed to connect to MongoDB",

--- a/src/api/chatbot/streamresponse.py
+++ b/src/api/chatbot/streamresponse.py
@@ -169,12 +169,12 @@ async def streamresponse(
             vault_url=Auth.vault_url, user_name=user_name, thread_id=thread_id
         )
         # If the thread does not belong to this user, fork it and continue with a different thread_id
-        thread_user = await Storage.get_user_id_for_thread(thread_id)
-        if thread_user and thread_user != user_name:
+        thread_owner = await Storage.get_user_id_for_thread(thread_id)
+        if thread_owner and thread_owner != user_name:
             old_thread_id = thread_id
             thread_id = await new_thread_id()
             logger.info(
-                f"Thread {old_thread_id} belongs to a different user ({thread_user}). Forking the thread for the current user with new thread_id: {thread_id}..."
+                f"Thread {old_thread_id} belongs to a different user ({thread_owner}). Forking the thread for the current user with new thread_id: {thread_id}..."
             )
             await Storage.fork_thread(old_thread_id, thread_id, user_name)
             logger = configure_logging(__name__, thread_id=thread_id, user_id=user_name)

--- a/src/services/storage/mongodb_storage.py
+++ b/src/services/storage/mongodb_storage.py
@@ -189,9 +189,6 @@ class ThreadStorage:
             "date": datetime.now(timezone.utc),
             "topic": doc.get("topic", ""),
             "content": content,
-            "root_thread_id": doc.get("root_thread_id", old_thread_id),
-            "parent_thread_id": old_thread_id,
-            "fork_from_index": 0,
         }
         await coll.insert_one(new_doc)
         logger.info(
@@ -254,7 +251,9 @@ class ThreadStorage:
         return total, threads
 
 
-def update_threadid_in_content(new_id: str, content: list[StreamVariant], logger):
+def update_threadid_in_content(
+    new_id: str, content: list[StreamVariant], logger
+) -> list[StreamVariant]:
     if isinstance(content[0], SVServerHint):
         content[0] = SVServerHint(data={"thread_id": new_id})
         logger.info("Updated ServerHint with new thread-id.")

--- a/src/services/storage/mongodb_storage.py
+++ b/src/services/storage/mongodb_storage.py
@@ -13,6 +13,7 @@ from src.services.streaming.stream_variants import (
     cleanup_conversation,
     from_sv_to_json,
     from_json_to_sv,
+    SVServerHint,
 )
 from src.core.logging_setup import configure_logging
 
@@ -33,7 +34,7 @@ class ThreadStorage:
         self.db = db
 
     @classmethod
-    async def create(cls, vault_url: str):
+    async def create(cls, vault_url: str) -> "ThreadStorage":
         if settings.DEV:
             db = AsyncMongoClient(settings.MONGODB_URI_DEV)[MONGODB_DATABASE_NAME]
         else:
@@ -154,6 +155,54 @@ class ThreadStorage:
             raise FileNotFoundError("Thread not found")
         return doc.get("content", [])
 
+    async def get_user_id_for_thread(self, thread_id: str) -> Optional[str]:
+        logger = configure_logging(__name__, thread_id=thread_id)
+        coll = self.db[MONGODB_COLLECTION_NAME]
+        doc = await coll.find_one({"thread_id": thread_id})
+        if not doc:
+            logger.warning(
+                "Thread not found in MongoDB when fetching user_id",
+                extra={"thread_id": thread_id},
+            )
+            return None
+        return doc.get("user_id")
+
+    async def fork_thread(self, old_thread_id: str, new_thread_id: str, user_id: str):
+        logger = configure_logging(__name__, thread_id=old_thread_id, user_id=user_id)
+        coll = self.db[MONGODB_COLLECTION_NAME]
+        doc = await coll.find_one({"thread_id": old_thread_id})
+        if not doc:
+            logger.warning(
+                "Thread not found in MongoDB when forking",
+                extra={"thread_id": old_thread_id},
+            )
+            raise FileNotFoundError("Thread not found")
+
+        content = doc.get("content", [])
+        content = [from_json_to_sv(v) for v in content]
+        content = update_threadid_in_content(new_thread_id, content, logger=logger)
+        content = [from_sv_to_json(v) for v in content]
+
+        new_doc = {
+            "user_id": user_id,
+            "thread_id": new_thread_id,
+            "date": datetime.now(timezone.utc),
+            "topic": doc.get("topic", ""),
+            "content": content,
+            "root_thread_id": doc.get("root_thread_id", old_thread_id),
+            "parent_thread_id": old_thread_id,
+            "fork_from_index": 0,
+        }
+        await coll.insert_one(new_doc)
+        logger.info(
+            "Forked thread in MongoDB",
+            extra={
+                "old_thread_id": old_thread_id,
+                "new_thread_id": new_thread_id,
+                "user_id": user_id,
+            },
+        )
+
     async def update_thread_topic(self, thread_id: str, topic: str):
         logger = configure_logging(__name__, thread_id=thread_id)
         coll = self.db[MONGODB_COLLECTION_NAME]
@@ -203,3 +252,19 @@ class ThreadStorage:
             for d in docs
         ]
         return total, threads
+
+
+def update_threadid_in_content(new_id: str, content: list[StreamVariant], logger):
+    if isinstance(content[0], SVServerHint):
+        content[0] = SVServerHint(data={"thread_id": new_id})
+        logger.info("Updated ServerHint with new thread-id.")
+    else:
+        if any(isinstance(c, SVServerHint) for c in content):
+            logger.exception("ServerHint is in unexpected position in thread content!")
+            raise ValueError("ServerHint is in unexpected position in thread content!")
+        else:
+            logger.info(
+                "ServerHint is missing in the thread content. It is inserted with the new thread-id."
+            )
+            content = [SVServerHint(data={"thread_id": new_id})] + content
+    return content

--- a/tests/unit_tests/test_thread_storage.py
+++ b/tests/unit_tests/test_thread_storage.py
@@ -52,3 +52,10 @@ async def test_save_and_read_thread(monkeypatch, patch_db, GOOD_HEADERS):
     # Prompt, User, Assistant, StreamEnd (no unexpected extra StreamEnd)
     assert kinds == ["Prompt", "User", "Assistant", "StreamEnd"]
     assert coll.storage[tid]["content"] == conv
+
+    # Check the user_id is stored correctly
+    assert (
+        coll.storage[tid]["user_id"]
+        == user_id
+        == await storage.get_user_id_for_thread(tid)
+    )


### PR DESCRIPTION
We have already assigned each thread to a user, but up until now, never used it in any way. 
These changes use this information to:
- disallow deletion of a stranger's thread
- disallow changing the topic of a stranger's thread
- check whether, when a thread is continued, it belongs to the user trying to continue it. If not, it is forked and the user may continue the thread without affecting the old thread

Note that the frontend needs to receive the new `thread_id` and edit the URL to reflect the new thread_id, so I cannot currently test it. It currently doesn't do it yet, but I have written Bianca about it. 