### PR TITLE
Userfeedback bugfix and endpoint responses update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Bind mounts expose `/work`, logs, threads, and shared `cache` to other Freva ser
 ## Quick Start (local dev)
 
 ### Requirements
-- Python `3.11.x`
-- LiteLLM instance that fronts OpenAI, Ollama, or Azure models and understands `litellm_config.yaml`
+- `podman` or `docker`
 
 <!-- ### Install dependencies (uv)
 ```bash
@@ -121,7 +120,6 @@ Generated artifacts that persist across runs:
 ## Development Workflow
 - **Run tests**: `uv run pytest` (or `uv run pytest tests/test_auth.py -k bearer` for focused cases). Tests cover auth flows, prompt assembly, storage, stream variant conversions, and route parameter validation.
 - **Interactive chat**: `uv run python scripts/dev_chat.py` starts a REPL that exercises the same orchestrator logic, persisting outputs to disk and optionally pointing at local MCP servers.
-- **Check kernel env**: `python scripts/check_kernel_env.py` verifies the code interpreter container has the expected libraries and env vars.
 
 ## Troubleshooting
 - **Auth failures**: verify headers include both `Authorization` and `x-freva-rest-url`. Inspect FastAPI logs for the exact HTTP status.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -140,7 +140,7 @@ services:
   freva-web:
     networks:
       - freva-gpt
-    image: ghcr.io/freva-org/freva-web:2604.0.0
+    image: ghcr.io/freva-org/freva-web:2604.1.1
     ports:
       - "8000:8000"
     container_name: freva-web

--- a/src/api/chatbot/deletethread.py
+++ b/src/api/chatbot/deletethread.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Response
 
 from src.services.service_factory import (
     Authenticator,
@@ -66,9 +66,9 @@ async def delete_thread(
             "Deleted thread from storage",
             extra={"thread_id": thread_id, "user_id": auth.username},
         )
-        return {"Successfully removed thread from storage."}
+        return {"detail": "Thread deleted."}
     except Exception as e:
-        logger.warning(
+        logger.exception(
             "Failed to delete thread from storage",
             extra={"thread_id": thread_id, "user_id": auth.username, "error": str(e)},
         )

--- a/src/api/chatbot/deletethread.py
+++ b/src/api/chatbot/deletethread.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Depends, Response
+from fastapi import APIRouter, HTTPException, Depends
 
 from src.services.service_factory import (
     Authenticator,

--- a/src/api/chatbot/getthread.py
+++ b/src/api/chatbot/getthread.py
@@ -94,7 +94,7 @@ async def get_thread(
         # Thread storage
         Storage = await get_thread_storage(vault_url=Auth.vault_url)
     except Exception as e:
-        logger.warning("Failed to connect to MongoDB", extra={"error": str(e)})
+        logger.exception("Failed to connect to MongoDB", extra={"error": str(e)})
         raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     try:

--- a/src/api/chatbot/getuserthreads.py
+++ b/src/api/chatbot/getuserthreads.py
@@ -76,7 +76,7 @@ async def get_user_threads(
         # Thread storage
         Storage: ThreadStorage = await get_thread_storage(vault_url=auth.vault_url)
     except Exception as e:
-        logger.warning("Failed to connect to MongoDB", extra={"error": str(e)})
+        logger.exception("Failed to connect to MongoDB", extra={"error": str(e)})
         raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     try:
@@ -107,7 +107,7 @@ async def get_user_threads(
             total_num_threads,
         ]
     except Exception as e:
-        logger.warning(
+        logger.exception(
             "Failed to fetch user history from storage", extra={"error": str(e)}
         )
         raise HTTPException(

--- a/src/api/chatbot/searchthreads.py
+++ b/src/api/chatbot/searchthreads.py
@@ -85,7 +85,7 @@ async def search_threads(
         # Thread storage
         Storage: ThreadStorage = await get_thread_storage(vault_url=auth.vault_url)
     except Exception as e:
-        logger.warning("Failed to connect to MongoDB: %s", e)
+        logger.exception("Failed to connect to MongoDB: %s", e)
         raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     num_threads = num_threads or 20  # default to 20 if not provided
@@ -96,7 +96,7 @@ async def search_threads(
             auth.username, query, num_threads, page
         )
     except Exception as e:
-        logger.warning("Failed to query threads: %s", e)
+        logger.exception("Failed to query threads: %s", e)
         raise HTTPException(status_code=500, detail="Failed to query threads.")
 
     return [

--- a/src/api/chatbot/setthreadtopic.py
+++ b/src/api/chatbot/setthreadtopic.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Response
 
 from src.services.service_factory import (
     Authenticator,
@@ -68,7 +68,7 @@ async def set_thread_topic(
         # Thread storage
         Storage = await get_thread_storage(vault_url=auth.vault_url)
     except Exception as e:
-        logger.warning("Failed to connect to MongoDB", extra={"error": str(e)})
+        logger.exception("Failed to connect to MongoDB", extra={"error": str(e)})
         raise HTTPException(status_code=503, detail="Failed to connect to MongoDB.")
 
     try:
@@ -77,9 +77,9 @@ async def set_thread_topic(
             "Updated thread topic",
             extra={"thread_id": thread_id, "user_id": auth.username},
         )
-        return {"Successfully updated thread topic."}
+        return {"detail": "Topic updated."}
     except Exception as e:
-        logger.warning(
+        logger.exception(
             "Failed to update thread topic",
             extra={"thread_id": thread_id, "user_id": auth.username, "error": str(e)},
         )

--- a/src/api/chatbot/setthreadtopic.py
+++ b/src/api/chatbot/setthreadtopic.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Depends, Response
+from fastapi import APIRouter, HTTPException, Depends
 
 from src.services.service_factory import (
     Authenticator,

--- a/src/api/chatbot/stop.py
+++ b/src/api/chatbot/stop.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query, HTTPException, Response
+from fastapi import APIRouter, Query, HTTPException
 from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
 
 from src.services.service_factory import AuthRequired

--- a/src/api/chatbot/stop.py
+++ b/src/api/chatbot/stop.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query, HTTPException
+from fastapi import APIRouter, Query, HTTPException, Response
 from starlette.status import HTTP_422_UNPROCESSABLE_CONTENT
 
 from src.services.service_factory import AuthRequired
@@ -35,8 +35,9 @@ async def stop_get(
         HTTPException (422):
             - If `thread_id` is missing or empty.
         HTTPException (404):
-            - If no active conversation with the given thread ID was found
-              or the stop request failed.
+            - If no active conversation with the given thread ID was found.
+        HTTPException (500):
+            - Failure to request stop.
     """
 
     if not thread_id:
@@ -47,12 +48,22 @@ async def stop_get(
 
     logger = configure_logging(__name__, thread_id=thread_id)
 
-    ok = await request_stop(thread_id)
-    logger.debug("Initiated stop request", extra={"thread_id": thread_id})
-
-    if ok:
-        return {"Conversation stopped."}
-    else:
+    try:
+        ok = await request_stop(thread_id)
+        if ok:
+            logger.debug("Initiated stop request", extra={"thread_id": thread_id})
+            return {"detail": "Conversation stopped."}
+        else:
+            logger.exception(
+                f"Thread not found in the registry. Nothing to stop: {thread_id}"
+            )
+            raise HTTPException(
+                status_code=404,
+                detail=f"Conversation with given thread-id not found in the registry: {thread_id}",
+            )
+    except Exception as e:
+        logger.exception(f"Failed to stop the thread {thread_id}: {e}")
         raise HTTPException(
-            status_code=404, detail="Conversation with given thread-id not found."
+            status_code=500,
+            detail=f"Failed to stop the conversation with thread-id: {thread_id}",
         )

--- a/src/api/chatbot/userfeedback.py
+++ b/src/api/chatbot/userfeedback.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Depends, Response
+from fastapi import APIRouter, HTTPException, Depends
 
 from src.services.service_factory import (
     Authenticator,

--- a/src/api/chatbot/userfeedback.py
+++ b/src/api/chatbot/userfeedback.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, HTTPException, Depends, Response
 
 from src.services.service_factory import (
     Authenticator,
@@ -57,8 +57,8 @@ async def user_feedback(
 
     Returns:
         dict:
-            - {"Successfully saved user feedback."} on successful save.
-            - {"Successfully removed user feedback."} on successful deletion.
+            - {"detail": "Feedback saved."} on successful save.
+            - {"detail": "Feedback removed."} on successful deletion.
 
     Raises:
         HTTPException (422):
@@ -148,7 +148,7 @@ async def user_feedback(
             logger.info(
                 f"Successfully saved user feedback at index {feedback_at_thread_index}: {thread_id}"
             )
-            return {"Successfully saved user feedback."}
+            return {"detail": "Feedback saved."}
         except Exception:
             logger.exception(
                 f"Failed to save user feedback at index {feedback_at_thread_index}: {thread_id}"
@@ -177,7 +177,7 @@ async def user_feedback(
             logger.info(
                 f"Successfully removed user feedback at index {feedback_at_thread_index}: {thread_id}"
             )
-            return {"Successfully removed user feedback."}
+            return {"detail": "Feedback removed."}
         except Exception:
             logger.exception(f"Failed to delete user feedback: {thread_id}")
             raise HTTPException(
@@ -196,4 +196,5 @@ async def save_feedback(
 
 async def delete_feedback(storage: ThreadStorage, thread_id, user_id, content, f_ind):
     await storage.delete_feedback(thread_id, user_id, content, f_ind)
-    await save_feedback_to_registry(thread_id, f_ind, "remove")
+    if await check_thread_exists(thread_id):
+        await save_feedback_to_registry(thread_id, f_ind, "remove")

--- a/src/services/streaming/active_conversations.py
+++ b/src/services/streaming/active_conversations.py
@@ -74,17 +74,14 @@ async def initialize_conversation(
     logger=None,
 ):
     """
-    Initialize and register a new conversation in the registry with the given thread_id and user_id.
+    Initialize and register a STREAMING conversation in the registry with the given thread_id and user_id.
     If a conversation with the same thread_id already exists, it will be updated to STREAMING state
     and the last_activity timestamp will be refreshed, but the existing conversation will stay unchanged.
     """
     log = logger or configure_logging(__name__, thread_id=thread_id, user_id=user_id)
     now = datetime.now(timezone.utc)
-    # if auth:
+    
     mcp_mgr = await get_mcp_manager(authenticator=auth, thread_id=thread_id)
-    # else:
-    #     log.warning(f"The conversation {thread_id} initialized without MCPManager! "
-    #                 "Please note that the MCP servers cannot be connected!")
 
     # Precreate the conversation object to reduce time spent under lock
     maybe_new_conv = ActiveConversation(

--- a/tests/api_integration_tests/test_routes_auth_matrix.py
+++ b/tests/api_integration_tests/test_routes_auth_matrix.py
@@ -79,4 +79,4 @@ async def test_routes_succeed_with_auth_and_username_injection(
                 "/api/chatbot/stop", params={"thread_id": "t-123"}, headers=GOOD_HEADERS
             )
             assert r.status_code == 200
-            assert r.json() == ["Conversation stopped."]
+            assert r.json().get("detail") == "Conversation stopped."

--- a/tests/api_integration_tests/test_userfeedback.py
+++ b/tests/api_integration_tests/test_userfeedback.py
@@ -88,7 +88,7 @@ async def test_userfeedback_save_success(
                 headers=GOOD_HEADERS,
             )
             assert r.status_code == 200
-            assert r.json() == ["Successfully saved user feedback."]
+            assert r.json().get("detail") == "Feedback saved."
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_userfeedback_remove_success(
                 headers=GOOD_HEADERS,
             )
             assert r.status_code == 200
-            assert r.json() == ["Successfully removed user feedback."]
+            assert r.json().get("detail") == "Feedback removed."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Changes:**
- Prevent registry writes when deleting feedback for non-registered threads; small docstring/return-message tweaks.
- Move chatbot success payloads to a consistent `{"detail": "<message>"}` shape across endpoints so clients/tests read uniform responses; update integration tests accordingly.
- Harden stop handler: differentiate “thread not found” (404) from internal stop failures (500), and log exceptions with context; similar logging upgrades in thread retrieval/search code to capture stack traces.

**Misc:**
- Docs/ops: Update README.md and bump freva-web dev image to 2604.1.1 in `docker-compose.dev.yml`.