### PR TITLE
Bugfix for root/parent thread id storage

### DIFF
--- a/src/api/chatbot/editthread.py
+++ b/src/api/chatbot/editthread.py
@@ -152,7 +152,7 @@ async def edit_thread(
     logger = configure_logging(__name__, thread_id=new_id, user_id=auth.username)
     base_sv = update_threadid_in_content(new_id, base_sv, logger=logger)
 
-    root_thread_id = source_thread_id
+    root_thread_id = await storage.get_root_id_for_thread(thread_id=source_thread_id)
 
     try:
         await storage.save_thread(

--- a/src/services/storage/mongodb_storage.py
+++ b/src/services/storage/mongodb_storage.py
@@ -83,6 +83,15 @@ class ThreadStorage:
                 merged_sv: List[StreamVariant] = existing_sv + content
             # topic: keep existing if present
             topic = existing.get("topic", "") or None
+            if not root_thread_id:
+                root_thread_id = existing.get("root_thread_id")
+                parent_thread_id = existing.get("parent_thread_id")
+                fork_from_index = existing.get("fork_from_index")
+        else:
+            if not root_thread_id:
+                root_thread_id = thread_id
+                parent_thread_id = thread_id
+                fork_from_index = 0
 
         # compute topic if missing
         if not topic or topic == "No topic yet":
@@ -95,9 +104,9 @@ class ThreadStorage:
             "date": datetime.now(timezone.utc),
             "topic": topic,
             "content": all_stream,
-            "root_thread_id": thread_id or root_thread_id,
-            "parent_thread_id": thread_id or parent_thread_id,
-            "fork_from_index": 0 or fork_from_index,
+            "root_thread_id": root_thread_id,
+            "parent_thread_id": parent_thread_id,
+            "fork_from_index": fork_from_index,
         }
 
         if existing:
@@ -205,6 +214,18 @@ class ThreadStorage:
             },
         )
 
+    async def get_root_id_for_thread(self, thread_id: str) -> Optional[str]:
+        logger = configure_logging(__name__, thread_id=thread_id)
+        coll = self.db[MONGODB_COLLECTION_NAME]
+        doc = await coll.find_one({"thread_id": thread_id})
+        if not doc:
+            logger.warning(
+                "Thread not found in MongoDB when fetching root_thread_id",
+                extra={"thread_id": thread_id},
+            )
+            return None
+        return doc.get("root_thread_id")
+
     async def update_thread_topic(self, thread_id: str, topic: str):
         logger = configure_logging(__name__, thread_id=thread_id)
         coll = self.db[MONGODB_COLLECTION_NAME]
@@ -218,7 +239,6 @@ class ThreadStorage:
     ):
         coll = self.db[MONGODB_COLLECTION_NAME]
         await coll.delete_one({"thread_id": thread_id})
-
 
     async def save_feedback(
         self,
@@ -246,7 +266,6 @@ class ThreadStorage:
 
         # Save feedback in the thread history
         await self._save_feedback_to_thread(thread_id, user_id, content_json, index, feedback)
- 
 
     async def delete_feedback(
         self,
@@ -261,7 +280,6 @@ class ThreadStorage:
 
         # Save feedback in the thread history
         await self._save_feedback_to_thread(thread_id, user_id, content_json, index, feedback="remove")
-        
 
     async def _save_feedback_to_thread(
         self,
@@ -278,7 +296,6 @@ class ThreadStorage:
 
         content_sv = [from_json_to_sv(l) for l in content_json]
         await self.save_thread(thread_id, user_id, content_sv)
-
 
     async def query_by_topic(
         self,


### PR DESCRIPTION
This PR fixes incorrect root_thread_id / parent_thread_id metadata when editing/forking threads so that thread lineage is preserved correctly in MongoDB and downstream features can reliably group related conversations.

**Changes**:
- Fix metadata handling to preserve existing root_thread_id, parent_thread_id, and fork_from_index when not explicitly provided, and to initialize them sensibly for new threads.
-  Implement propagating root-id from parent thread to child.