### PR TITLE
Update thread store with each completed variant

### DIFF
--- a/src/api/chatbot/streamresponse.py
+++ b/src/api/chatbot/streamresponse.py
@@ -213,7 +213,7 @@ async def streamresponse(
             hint_v = SVServerHint(data={"thread_id": thread_id})
             for data in _sse_data(from_sv_to_json(hint_v)):
                 yield data
-            await add_to_conversation(thread_id, [hint_v])
+            await add_to_conversation(thread_id, [hint_v], storage=storage)
 
         last_check = time.monotonic()
         async for variant in run_stream(
@@ -221,6 +221,7 @@ async def streamresponse(
             thread_id=thread_id,
             user_input=input,
             system_prompt=system_prompt,
+            storage=storage,
             logger=logger,
         ):
             for data in _sse_data(from_sv_to_json(variant)):

--- a/src/services/streaming/active_conversations.py
+++ b/src/services/streaming/active_conversations.py
@@ -133,6 +133,7 @@ async def initialize_conversation(
 async def add_to_conversation(
     thread_id: str,
     messages: List[StreamVariant],
+    storage: ThreadStorage,
 ) -> ActiveConversation:
     """
     Check if an ActiveConversation exists for thread_id and append new variants.
@@ -144,7 +145,12 @@ async def add_to_conversation(
             raise ValueError("Conversation does not exist. Please initialize first!")
         conv.messages.extend(messages)
         conv.last_activity = datetime.now(timezone.utc)
-        return conv
+
+    # Save conversation
+    await storage.save_thread(
+        conv.thread_id, conv.user_id, conv.messages, append_to_existing=False
+    )
+    return conv
 
 
 async def get_conversation_state(thread_id: str) -> Optional[ConversationState]:

--- a/src/services/streaming/active_conversations.py
+++ b/src/services/streaming/active_conversations.py
@@ -148,7 +148,7 @@ async def add_to_conversation(
 
     # Save conversation
     await storage.save_thread(
-        conv.thread_id, conv.user_id, conv.messages, append_to_existing=False
+        conv.thread_id, conv.user_id, conv.messages
     )
     return conv
 
@@ -216,7 +216,7 @@ async def end_and_save_conversation(
         conv.last_activity = datetime.now(timezone.utc)
         # Save conversation
         await Storage.save_thread(
-            conv.thread_id, conv.user_id, conv.messages, append_to_existing=False
+            conv.thread_id, conv.user_id, conv.messages
         )
         return True
 

--- a/src/services/streaming/stream_orchestrator.py
+++ b/src/services/streaming/stream_orchestrator.py
@@ -65,6 +65,7 @@ async def stream_with_tools(
     messages: List[Dict[str, Any]],  # system_prompt
     acomplete_func=acomplete,
     stream_state: StreamState,
+    storage: ThreadStorage,
     logger=None,
 ) -> AsyncIterator[StreamVariant]:
     log = logger or DEFAULT_LOGGER
@@ -136,7 +137,7 @@ async def stream_with_tools(
 
     if accumulated_asst_text:
         asst_v = SVAssistant(text="".join(accumulated_asst_text))
-        await add_to_conversation(thread_id, [asst_v])
+        await add_to_conversation(thread_id, [asst_v], storage=storage)
 
     # If no tool calls, wrap up everything and return
     if not tool_calls:
@@ -160,6 +161,8 @@ async def stream_with_tools(
             tool_v = SVToolCall(arg=args_txt, id=id, tool_name=name)
             # code is already streamed, we stream the other tool calls here too
             yield tool_v 
+
+        await add_to_conversation(thread_id, [tool_v], storage=storage)
 
         async def run_with_heartbeat():
             """Run the tool while periodically sending heartbeats."""
@@ -212,10 +215,6 @@ async def stream_with_tools(
             log.exception("Tool %s failed", name)
             result_text = json.dumps({"error": str(e)})
 
-        # We collect tool input and output as Stream Variants and append to thread
-        tc_variants: List[StreamVariant] = []
-        tc_variants.append(tool_v)
-
         tool_out_v: List[StreamVariant] = []
         tool_msgs: List[Dict[str, Any]] = []
         # Parsing tool call output as StreamVariants and messages to model
@@ -229,8 +228,7 @@ async def stream_with_tools(
             else:
                 yield r  # Streaming the result to endpoint
 
-        tc_variants.extend(tool_out_v)
-        await add_to_conversation(thread_id, tc_variants)
+        await add_to_conversation(thread_id, tool_out_v, storage=storage)
 
         if tool_msgs:
             messages.extend(tool_msgs)
@@ -247,6 +245,7 @@ async def run_stream(
     thread_id: str,
     user_input: str,
     system_prompt: List[Dict[str, Any]],
+    storage: ThreadStorage,
     logger=None,
 ) -> AsyncGenerator[StreamVariant, None]:
     """
@@ -256,7 +255,7 @@ async def run_stream(
 
     # Append user content
     user_v = SVUser(text=user_input or "")
-    await add_to_conversation(thread_id, [user_v])
+    await add_to_conversation(thread_id, [user_v], storage=storage)
 
     stream_state = StreamState()
 
@@ -272,6 +271,7 @@ async def run_stream(
                 model=model,
                 acomplete_func=acomplete,
                 stream_state=stream_state,
+                storage=storage,
                 logger=log,
             ):
                 yield piece
@@ -284,7 +284,7 @@ async def run_stream(
             log.exception("Stream error: %s", e)
             err_v = SVServerError(message=str(e))
             end_v = SVStreamEnd(message="Stream ended with an error.")
-            await add_to_conversation(thread_id, [err_v])
+            await add_to_conversation(thread_id, [err_v], storage=storage)
             stream_state.finished = True
             yield err_v
             yield end_v


### PR DESCRIPTION
This PR updates the thread store as each variant is completed, and ensures streamed conversations (including tool-call inputs/outputs) are reliably persisted to the thread storage backend as they happen, instead of only living in-memory until the end of the stream.

**Changes:**

- Update `add_to_conversation` to require `storage: ThreadStorage` and save the thread to storage after appending new variants.
- Persist user/assistant/tool-call/tool-output/error variants via `add_to_conversation(..., storage=storage)` when they are added to the conversation in the registry.
