### PR TITLE
Add parameter to opt out from saving the thread in mongoDB

### DIFF
--- a/src/api/chatbot/streamresponse.py
+++ b/src/api/chatbot/streamresponse.py
@@ -64,6 +64,7 @@ async def streamresponse(
     thread_id: Optional[str] = Query(None),
     input: Optional[str] = Query(None),
     chatbot: Optional[str] = Query(None),
+    store_thread: bool = True,
     auth: Authenticator = Depends(auth_dependency),
     storage: ThreadStorage = Depends(get_thread_storage),
 ):
@@ -213,7 +214,7 @@ async def streamresponse(
             hint_v = SVServerHint(data={"thread_id": thread_id})
             for data in _sse_data(from_sv_to_json(hint_v)):
                 yield data
-            await add_to_conversation(thread_id, [hint_v], storage=storage)
+            await add_to_conversation(thread_id, [hint_v], storage=storage, store_thread=store_thread)
 
         last_check = time.monotonic()
         async for variant in run_stream(
@@ -222,6 +223,7 @@ async def streamresponse(
             user_input=input,
             system_prompt=system_prompt,
             storage=storage,
+            store_thread=store_thread,
             logger=logger,
         ):
             for data in _sse_data(from_sv_to_json(variant)):
@@ -237,16 +239,17 @@ async def streamresponse(
                     for data in _sse_data(from_sv_to_json(end_v)):
                         yield data
                     await cancel_tool_tasks(thread_id)
-                    await end_and_save_conversation(thread_id, storage)
+                    await end_and_save_conversation(thread_id, storage, store_thread=store_thread)
                     logger.info(
                         "Stopped streaming after client request",
                         extra={"thread_id": thread_id, "user_id": user_name},
                     )
                     return
 
-        await end_and_save_conversation(thread_id, storage)
+        await end_and_save_conversation(thread_id, storage, store_thread=store_thread)
+        msg = "Completed streaming and saved conversation" if store_thread else "Completed streaming without saving the conversation"
         logger.info(
-            "Completed streaming and saved conversation",
+            msg,
             extra={"thread_id": thread_id, "user_id": user_name},
         )
 

--- a/src/services/streaming/active_conversations.py
+++ b/src/services/streaming/active_conversations.py
@@ -134,6 +134,7 @@ async def add_to_conversation(
     thread_id: str,
     messages: List[StreamVariant],
     storage: ThreadStorage,
+    store_thread: bool = True
 ) -> ActiveConversation:
     """
     Check if an ActiveConversation exists for thread_id and append new variants.
@@ -146,10 +147,11 @@ async def add_to_conversation(
         conv.messages.extend(messages)
         conv.last_activity = datetime.now(timezone.utc)
 
-    # Save conversation
-    await storage.save_thread(
-        conv.thread_id, conv.user_id, conv.messages
-    )
+    if store_thread:
+        # Save conversation
+        await storage.save_thread(
+            conv.thread_id, conv.user_id, conv.messages
+        )
     return conv
 
 
@@ -201,6 +203,7 @@ async def request_stop(thread_id: str) -> bool:
 async def end_and_save_conversation(
     thread_id: str,
     Storage: ThreadStorage,
+    store_thread: bool = True
 ) -> bool:
     """
     Mark a conversation as ENDED but keep it in the registry and save to available
@@ -215,10 +218,12 @@ async def end_and_save_conversation(
         conv.state = ConversationState.ENDED
         conv.last_activity = datetime.now(timezone.utc)
         # Save conversation
+
+    if store_thread:
         await Storage.save_thread(
             conv.thread_id, conv.user_id, conv.messages
         )
-        return True
+    return True
 
 
 async def remove_conversation(thread_id: str) -> bool:

--- a/src/services/streaming/stream_orchestrator.py
+++ b/src/services/streaming/stream_orchestrator.py
@@ -66,6 +66,7 @@ async def stream_with_tools(
     acomplete_func=acomplete,
     stream_state: StreamState,
     storage: ThreadStorage,
+    store_thread: bool = True,
     logger=None,
 ) -> AsyncIterator[StreamVariant]:
     log = logger or DEFAULT_LOGGER
@@ -137,7 +138,7 @@ async def stream_with_tools(
 
     if accumulated_asst_text:
         asst_v = SVAssistant(text="".join(accumulated_asst_text))
-        await add_to_conversation(thread_id, [asst_v], storage=storage)
+        await add_to_conversation(thread_id, [asst_v], storage=storage, store_thread=store_thread)
 
     # If no tool calls, wrap up everything and return
     if not tool_calls:
@@ -162,7 +163,7 @@ async def stream_with_tools(
             # code is already streamed, we stream the other tool calls here too
             yield tool_v 
 
-        await add_to_conversation(thread_id, [tool_v], storage=storage)
+        await add_to_conversation(thread_id, [tool_v], storage=storage, store_thread=store_thread)
 
         async def run_with_heartbeat():
             """Run the tool while periodically sending heartbeats."""
@@ -228,7 +229,7 @@ async def stream_with_tools(
             else:
                 yield r  # Streaming the result to endpoint
 
-        await add_to_conversation(thread_id, tool_out_v, storage=storage)
+        await add_to_conversation(thread_id, tool_out_v, storage=storage, store_thread=store_thread)
 
         if tool_msgs:
             messages.extend(tool_msgs)
@@ -246,6 +247,7 @@ async def run_stream(
     user_input: str,
     system_prompt: List[Dict[str, Any]],
     storage: ThreadStorage,
+    store_thread: bool = True,
     logger=None,
 ) -> AsyncGenerator[StreamVariant, None]:
     """
@@ -255,7 +257,7 @@ async def run_stream(
 
     # Append user content
     user_v = SVUser(text=user_input or "")
-    await add_to_conversation(thread_id, [user_v], storage=storage)
+    await add_to_conversation(thread_id, [user_v], storage=storage, store_thread=store_thread)
 
     stream_state = StreamState()
 
@@ -272,6 +274,7 @@ async def run_stream(
                 acomplete_func=acomplete,
                 stream_state=stream_state,
                 storage=storage,
+                store_thread=store_thread,
                 logger=log,
             ):
                 yield piece
@@ -284,7 +287,7 @@ async def run_stream(
             log.exception("Stream error: %s", e)
             err_v = SVServerError(message=str(e))
             end_v = SVStreamEnd(message="Stream ended with an error.")
-            await add_to_conversation(thread_id, [err_v], storage=storage)
+            await add_to_conversation(thread_id, [err_v], storage=storage, store_thread=store_thread)
             stream_state.finished = True
             yield err_v
             yield end_v


### PR DESCRIPTION
This PR enables clients to opt out of persisting chat threads in MongoDB while still using the streaming API, reducing unwanted storage and keeping ephemeral sessions lightweight.

**Changes:**

- Added a `store_thread` flag (default `True`) to `\streamresponse` to control whether the conversation is persisted.
- Plumbed `store_thread` through the streaming pipeline (`run_stream`, `stream_with_tools`) so all message variants respect the persistence setting.
- Updated `add_to_conversation` and `end_and_save_conversation` to skip `ThreadStorage.save_thread(...)` when `store_thread=False`.
- Adjusted completion logging to reflect whether the conversation was saved or intentionally not stored.