### PR TITLE
Bugfix/ Local dev scripts mongo connection

### DIFF
--- a/scripts/dev_benchmark_script.py
+++ b/scripts/dev_benchmark_script.py
@@ -11,6 +11,7 @@ os.environ["CLIMATECLAW_LITE_LLM_ADDRESS"] = "http://localhost:4000"
 os.environ["CLIMATECLAW_RAG_SERVER_URL"] = "http://localhost:8050"
 os.environ["CLIMATECLAW_CODE_SERVER_URL"] = "http://localhost:8051"
 os.environ["CLIMATECLAW_WEB_SEARCH_SERVER_URL"] = "http://localhost:8052"
+os.environ["CLIMATECLAW_MONGODB_HOST"] = "localhost"
 
 
 import asyncio
@@ -47,8 +48,8 @@ Headless dev/benchmark runner mirroring /chatbot/streamresponse behaviour.
 # ──────────────────────────────────────────────────────────────────────────────
 
 MODEL = "gpt-4.1"
-USER_ID = "dev_user"
-PROMPT = "Make an annual mean temperature global map plot for the year 2023"
+USER_ID = "janedoe"
+PROMPT = "plot x=y"
 
 RUNS = 3
 CONCURRENCY = 3  # ← set to 1 for clean mode

--- a/scripts/dev_chat.py
+++ b/scripts/dev_chat.py
@@ -70,7 +70,7 @@ settings = get_settings()
 # ──────────────────────────────────────────────────────────────────────────────
 
 MODEL = "gpt-4.1"
-USER_ID = "dev_user"
+USER_ID = "janedoe"
 
 PRINT_DEBUG = False  # Print non-Assistant stream variants (ServerHint, etc.)
 SHOW_STATS = True  # Show per-turn simple stats

--- a/scripts/dev_chat.py
+++ b/scripts/dev_chat.py
@@ -11,6 +11,8 @@ os.environ["CLIMATECLAW_LITE_LLM_ADDRESS"] = "http://localhost:4000"
 os.environ["CLIMATECLAW_RAG_SERVER_URL"] = "http://localhost:8050"
 os.environ["CLIMATECLAW_CODE_SERVER_URL"] = "http://localhost:8051"
 os.environ["CLIMATECLAW_WEB_SEARCH_SERVER_URL"] = "http://localhost:8052"
+os.environ["CLIMATECLAW_MONGODB_HOST"] = "localhost"
+
 
 import asyncio
 import logging

--- a/src/climateclaw/services/storage/helpers.py
+++ b/src/climateclaw/services/storage/helpers.py
@@ -58,5 +58,9 @@ def get_mongodb_uri() -> str:
         raise ValueError(
             "Please set the MongoDB user and password in environment variables!"
         )
-    uri = f"mongodb://{user}:{password}@mongodb:27017"
+
+    host = os.getenv("CLIMATECLAW_MONGODB_HOST", "mongodb")
+    port = os.getenv("CLIMATECLAW_MONGODB_PORT", "27017")
+
+    uri = f"mongodb://{user}:{password}@{host}:{port}"
     return uri


### PR DESCRIPTION
Local dev scripts need to connect to MongoDB from outside the Docker network, where the hardcoded mongodb:27017 service address is not resolvable.

**Changes:**

- Added CLIMATECLAW_MONGODB_HOST and CLIMATECLAW_MONGODB_PORT support to get_mongodb_uri(), defaulting to the existing Docker service address.
- Set CLIMATECLAW_MONGODB_HOST=localhost in scripts/dev_chat.py and scripts/dev_benchmark_script.py for local benchmark runs.
- Updated the scripts’s default test user and prompt.