### PR TITLE
Queue code interpreter calls during history replay

### DIFF
--- a/src/climateclaw/services/streaming/active_conversations.py
+++ b/src/climateclaw/services/streaming/active_conversations.py
@@ -15,6 +15,7 @@ from climateclaw.services.service_factory import (
 from climateclaw.services.streaming.stream_variants import (
     StreamVariant,
     SVCode,
+    SVServerHint,
     from_json_to_sv,
     from_sv_to_json,
 )
@@ -35,6 +36,7 @@ class ActiveConversation:
     user_id: str
     state: ConversationState
     mcp_manager: McpManager | None
+    replay_task: asyncio.Task | None = None
     tool_tasks: set[asyncio.Task] = field(default_factory=set)
     messages: list[StreamVariant] = field(default_factory=list)
     last_activity: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
@@ -126,10 +128,11 @@ async def initialize_conversation(
     if mcp_mgr is not None and any(isinstance(v, SVCode) for v in messages):
         loop = asyncio.get_running_loop()
         task = loop.create_task(_replay_code_history(thread_id))
+        await set_replay_task(thread_id, task)
         await register_tool_task(thread_id, task)
         task.add_done_callback(
             # to be unregistered when done
-            lambda t: asyncio.create_task(unregister_tool_task(thread_id, t))
+            lambda t: asyncio.create_task(_cleanup_replay_task(thread_id, t))
         )
 
 
@@ -296,6 +299,55 @@ async def _replay_code_history(thread_id: str) -> None:
             )
             # break on first failure; might replace with `continue`
             break
+
+
+async def set_replay_task(thread_id: str, task: asyncio.Task) -> None:
+    """
+    Store the active replay task for this conversation so later code tool calls
+    can wait for kernel state restoration before using the same MCP client.
+    """
+    async with RegistryLock:
+        conv = Registry.get(thread_id)
+        if conv:
+            conv.replay_task = task
+
+
+async def get_replay_task(thread_id: str) -> asyncio.Task | None:
+    """
+    Return the replay task for this conversation if one is currently known.
+    """
+    async with RegistryLock:
+        conv = Registry.get(thread_id)
+        return conv.replay_task if conv else None
+
+
+async def clear_replay_task(thread_id: str, task: asyncio.Task) -> None:
+    """
+    Clear the replay task reference, but only if it still points at this task.
+    """
+    async with RegistryLock:
+        conv = Registry.get(thread_id)
+        if conv and conv.replay_task is task:
+            conv.replay_task = None
+
+
+async def _cleanup_replay_task(thread_id: str, task: asyncio.Task) -> None:
+    await unregister_tool_task(thread_id, task)
+    await clear_replay_task(thread_id, task)
+
+
+async def wait_for_replay_if_needed(thread_id: str):
+    """
+    Yield status hints and wait when code history replay is still restoring the
+    kernel state for this conversation.
+    """
+    task = await get_replay_task(thread_id)
+    if task is None or task.done():
+        return
+
+    yield SVServerHint(data={"status": "Executing previous code blocks..."})
+    await task
+    yield SVServerHint(data={"status": "Execution of previous code blocks is done."})
 
 
 async def register_tool_task(thread_id: str, task: asyncio.Task) -> None:

--- a/src/climateclaw/services/streaming/stream_orchestrator.py
+++ b/src/climateclaw/services/streaming/stream_orchestrator.py
@@ -20,6 +20,7 @@ from climateclaw.services.streaming.active_conversations import (
     initialize_conversation,
     register_tool_task,
     unregister_tool_task,
+    wait_for_replay_if_needed,
 )
 from climateclaw.services.streaming.litellm_client import acomplete, first_text
 from climateclaw.services.streaming.stream_variants import (
@@ -160,6 +161,9 @@ async def stream_with_tools(
         args_txt = (tc.get("function") or {}).get("arguments", "")
 
         if name == "code_interpreter":
+            async for hint in wait_for_replay_if_needed(thread_id):
+                yield hint
+
             # accumulated code text to be appended to thread
             tool_v = SVCode(code=args_txt, id=id)
         else:

--- a/tests/unit_tests/test_replay_queue.py
+++ b/tests/unit_tests/test_replay_queue.py
@@ -1,0 +1,155 @@
+import asyncio
+import json
+
+import pytest
+
+import climateclaw.services.streaming.stream_orchestrator as orchestrator
+from climateclaw.services.streaming.active_conversations import (
+    Registry,
+    wait_for_replay_if_needed,
+)
+from climateclaw.services.streaming.stream_orchestrator import (
+    StreamState,
+    stream_with_tools,
+)
+from climateclaw.services.streaming.stream_variants import (
+    SVCode,
+    SVCodeOutput,
+    SVServerHint,
+)
+from conftest import DummyMcpManager
+
+
+class CodeToolMcpManager(DummyMcpManager):
+    async def openai_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "code_interpreter",
+                    "description": "Execute Python code",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+
+
+async def fake_code_interpreter_stream():
+    yield {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "function": {
+                                "name": "code_interpreter",
+                                "arguments": '{"code": "print(2)"}',
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_wait_for_replay_if_needed_yields_status_hints(patch_registry):
+    release_replay = asyncio.Event()
+
+    async def replay():
+        await release_replay.wait()
+
+    task = asyncio.create_task(replay())
+    patch_registry({"t-replay": []})
+    Registry["t-replay"].replay_task = task
+
+    hints = []
+
+    async def collect_hints():
+        async for hint in wait_for_replay_if_needed("t-replay"):
+            hints.append(hint)
+
+    waiter = asyncio.create_task(collect_hints())
+    await asyncio.sleep(0)
+
+    assert hints == [SVServerHint(data={"status": "Executing previous code blocks..."})]
+    assert not waiter.done()
+
+    release_replay.set()
+    await waiter
+
+    assert hints == [
+        SVServerHint(data={"status": "Executing previous code blocks..."}),
+        SVServerHint(data={"status": "Execution of previous code blocks is done."}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_code_interpreter_waits_for_replay_before_mcp_call(
+    patch_registry, patch_thread_storage, monkeypatch
+):
+    release_replay = asyncio.Event()
+    mcp_called = asyncio.Event()
+
+    async def replay():
+        await release_replay.wait()
+
+    replay_task = asyncio.create_task(replay())
+    patch_registry({"t-stream": []})
+    Registry["t-stream"].mcp_manager = CodeToolMcpManager()
+    Registry["t-stream"].replay_task = replay_task
+
+    async def fake_acomplete(**kwargs):
+        return fake_code_interpreter_stream()
+
+    async def fake_run_tool_via_mcp(**kwargs):
+        mcp_called.set()
+        return json.dumps(
+            {
+                "structuredContent": {
+                    "stdout": "2\n",
+                    "stderr": "",
+                    "display_data": [],
+                }
+            }
+        )
+
+    monkeypatch.setattr(orchestrator, "run_tool_via_mcp", fake_run_tool_via_mcp)
+
+    stream = stream_with_tools(
+        model="test-model",
+        thread_id="t-stream",
+        messages=[],
+        acomplete_func=fake_acomplete,
+        stream_state=StreamState(),
+        storage=patch_thread_storage,
+        store_thread=False,
+    )
+
+    first = await anext(stream)
+    second = await anext(stream)
+
+    assert isinstance(first, SVCode)
+    assert second == SVServerHint(data={"status": "Executing previous code blocks..."})
+    assert not mcp_called.is_set()
+
+    release_replay.set()
+
+    seen_done_hint = False
+    seen_code_output = False
+    async for item in stream:
+        if item == SVServerHint(
+            data={"status": "Execution of previous code blocks is done."}
+        ):
+            seen_done_hint = True
+        if isinstance(item, SVCodeOutput):
+            seen_code_output = True
+            break
+
+    assert seen_done_hint
+    assert seen_code_output
+    assert mcp_called.is_set()


### PR DESCRIPTION
This PR ensures code interpreter calls do not race with code-history replay when reopening a conversation, so the MCP/kernel state is restored before new code executes. It closes #63 .

**Changes:**
- Track the active code-history replay task on each active conversation.
- Add replay task helpers to set, get, clear, and clean up replay state alongside existing tool task registration.
- Add `wait_for_replay_if_needed` to emit server status hints while previous code blocks are replaying.
- Update `stream_with_tools` so `code_interpreter` tool calls wait for replay completion before invoking the MCP tool.
- Add unit tests covering replay status hints and verifying code interpreter execution is blocked until replay finishes.