### PR TITLE
Stream ServerHint for code replay

### DIFF
--- a/src/climateclaw/services/streaming/active_conversations.py
+++ b/src/climateclaw/services/streaming/active_conversations.py
@@ -15,7 +15,6 @@ from climateclaw.services.service_factory import (
 from climateclaw.services.streaming.stream_variants import (
     StreamVariant,
     SVCode,
-    SVServerHint,
     from_json_to_sv,
     from_sv_to_json,
 )
@@ -314,11 +313,14 @@ async def set_replay_task(thread_id: str, task: asyncio.Task) -> None:
 
 async def get_replay_task(thread_id: str) -> asyncio.Task | None:
     """
-    Return the replay task for this conversation if one is currently known.
+    Return the active replay task for this conversation if one is currently known.
     """
     async with RegistryLock:
         conv = Registry.get(thread_id)
-        return conv.replay_task if conv else None
+        task = conv.replay_task if conv else None
+    if task is None or task.done():
+        return None
+    return task
 
 
 async def clear_replay_task(thread_id: str, task: asyncio.Task) -> None:
@@ -334,20 +336,6 @@ async def clear_replay_task(thread_id: str, task: asyncio.Task) -> None:
 async def _cleanup_replay_task(thread_id: str, task: asyncio.Task) -> None:
     await unregister_tool_task(thread_id, task)
     await clear_replay_task(thread_id, task)
-
-
-async def wait_for_replay_if_needed(thread_id: str):
-    """
-    Yield status hints and wait when code history replay is still restoring the
-    kernel state for this conversation.
-    """
-    task = await get_replay_task(thread_id)
-    if task is None or task.done():
-        return
-
-    yield SVServerHint(data={"status": "Executing previous code blocks..."})
-    await task
-    yield SVServerHint(data={"status": "Execution of previous code blocks is done."})
 
 
 async def register_tool_task(thread_id: str, task: asyncio.Task) -> None:

--- a/src/climateclaw/services/streaming/replay_gate.py
+++ b/src/climateclaw/services/streaming/replay_gate.py
@@ -1,0 +1,38 @@
+import asyncio
+from dataclasses import dataclass
+
+from climateclaw.services.streaming.stream_variants import SVServerHint
+
+REPLAYING_CODE_STATUS = "Executing previous code blocks..."
+REPLAY_DONE_STATUS = "Execution of previous code blocks is done."
+
+
+@dataclass
+class ReplayGate:
+    task: asyncio.Task | None
+    start_sent: bool = False
+    done_sent: bool = False
+
+    def start_hint(self) -> SVServerHint | None:
+        if self.start_sent or self.task is None or self.task.done():
+            return None
+
+        self.start_sent = True
+        return SVServerHint(data={"status": REPLAYING_CODE_STATUS})
+
+    def done_hint_if_ready(self) -> SVServerHint | None:
+        if self.done_sent or self.task is None or not self.task.done():
+            return None
+
+        self.done_sent = True
+        return SVServerHint(data={"status": REPLAY_DONE_STATUS})
+
+    async def wait_done_hint(self) -> SVServerHint | None:
+        if self.done_sent or self.task is None:
+            return None
+
+        if not self.task.done():
+            await self.task
+
+        self.done_sent = True
+        return SVServerHint(data={"status": REPLAY_DONE_STATUS})

--- a/src/climateclaw/services/streaming/stream_orchestrator.py
+++ b/src/climateclaw/services/streaming/stream_orchestrator.py
@@ -17,12 +17,13 @@ from climateclaw.services.streaming.active_conversations import (
     get_conv_mcpmanager,
     get_conv_messages,
     get_conversation_state,
+    get_replay_task,
     initialize_conversation,
     register_tool_task,
     unregister_tool_task,
-    wait_for_replay_if_needed,
 )
 from climateclaw.services.streaming.litellm_client import acomplete, first_text
+from climateclaw.services.streaming.replay_gate import ReplayGate
 from climateclaw.services.streaming.stream_variants import (
     OpenAIMessage,
     StreamVariant,
@@ -52,6 +53,7 @@ class StreamState:
     user_invoked: bool = True
     tool_call: dict[str, Any] | None = None
     finished: bool = False
+    replay_gate: ReplayGate | None = None
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -83,6 +85,12 @@ async def stream_with_tools(
 
     # Get MCPManager of the conversation
     mcp = await get_conv_mcpmanager(thread_id)
+
+    if stream_state.replay_gate is None:
+        stream_state.replay_gate = ReplayGate(await get_replay_task(thread_id))
+
+    if hint := stream_state.replay_gate.start_hint():
+        yield hint
 
     # 1) First request
     tool_agg: dict[str, Any] = {}
@@ -147,6 +155,9 @@ async def stream_with_tools(
 
     # If no tool calls, wrap up everything and return
     if not tool_calls:
+        if hint := await stream_state.replay_gate.wait_done_hint():
+            yield hint
+
         end_v = SVStreamEnd(message="Stream ended.")
         yield end_v
         stream_state.finished = True
@@ -161,7 +172,7 @@ async def stream_with_tools(
         args_txt = (tc.get("function") or {}).get("arguments", "")
 
         if name == "code_interpreter":
-            async for hint in wait_for_replay_if_needed(thread_id):
+            if hint := await stream_state.replay_gate.wait_done_hint():
                 yield hint
 
             # accumulated code text to be appended to thread
@@ -287,6 +298,9 @@ async def stream_with_tools(
         await add_to_conversation(
             thread_id, tool_out_v, storage=storage, store_thread=store_thread
         )
+
+        if hint := stream_state.replay_gate.done_hint_if_ready():
+            yield hint
 
         if tool_msgs:
             messages.extend(tool_msgs)  # type: ignore[arg-type]

--- a/tests/unit_tests/test_replay_queue.py
+++ b/tests/unit_tests/test_replay_queue.py
@@ -4,34 +4,49 @@ import json
 import pytest
 
 import climateclaw.services.streaming.stream_orchestrator as orchestrator
-from climateclaw.services.streaming.active_conversations import (
-    Registry,
-    wait_for_replay_if_needed,
+from climateclaw.services.streaming.active_conversations import Registry
+from climateclaw.services.streaming.replay_gate import (
+    REPLAY_DONE_STATUS,
+    REPLAYING_CODE_STATUS,
 )
 from climateclaw.services.streaming.stream_orchestrator import (
     StreamState,
     stream_with_tools,
 )
 from climateclaw.services.streaming.stream_variants import (
+    SVAssistant,
     SVCode,
     SVCodeOutput,
     SVServerHint,
+    SVStreamEnd,
 )
 from conftest import DummyMcpManager
 
+REPLAYING_HINT = SVServerHint(data={"status": REPLAYING_CODE_STATUS})
+REPLAY_DONE_HINT = SVServerHint(data={"status": REPLAY_DONE_STATUS})
 
-class CodeToolMcpManager(DummyMcpManager):
-    async def openai_tools(self):
+
+class ToolMcpManager(DummyMcpManager):
+    def __init__(self, tool_name: str):
+        self.tool_name = tool_name
+
+    def _tools(self):
         return [
             {
                 "type": "function",
                 "function": {
-                    "name": "code_interpreter",
-                    "description": "Execute Python code",
+                    "name": self.tool_name,
+                    "description": f"Run {self.tool_name}",
                     "parameters": {"type": "object"},
                 },
             }
         ]
+
+    async def openai_tools(self):
+        return self._tools()
+
+    async def available_tools(self):
+        return self._tools()
 
 
 async def fake_code_interpreter_stream():
@@ -42,7 +57,7 @@ async def fake_code_interpreter_stream():
                     "tool_calls": [
                         {
                             "index": 0,
-                            "id": "call_1",
+                            "id": "call_code",
                             "function": {
                                 "name": "code_interpreter",
                                 "arguments": '{"code": "print(2)"}',
@@ -56,52 +71,60 @@ async def fake_code_interpreter_stream():
     }
 
 
-@pytest.mark.asyncio
-async def test_wait_for_replay_if_needed_yields_status_hints(patch_registry):
+async def fake_web_search_stream():
+    yield {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_web",
+                            "function": {
+                                "name": "web_search",
+                                "arguments": '{"query": "climate"}',
+                            },
+                        }
+                    ]
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+
+
+async def fake_plain_text_stream():
+    yield {
+        "choices": [
+            {
+                "delta": {"content": "plain answer"},
+                "finish_reason": "stop",
+            }
+        ]
+    }
+
+
+def set_replay_conversation(patch_registry, thread_id: str, tool_name: str):
     release_replay = asyncio.Event()
 
     async def replay():
         await release_replay.wait()
 
-    task = asyncio.create_task(replay())
-    patch_registry({"t-replay": []})
-    Registry["t-replay"].replay_task = task
-
-    hints = []
-
-    async def collect_hints():
-        async for hint in wait_for_replay_if_needed("t-replay"):
-            hints.append(hint)
-
-    waiter = asyncio.create_task(collect_hints())
-    await asyncio.sleep(0)
-
-    assert hints == [SVServerHint(data={"status": "Executing previous code blocks..."})]
-    assert not waiter.done()
-
-    release_replay.set()
-    await waiter
-
-    assert hints == [
-        SVServerHint(data={"status": "Executing previous code blocks..."}),
-        SVServerHint(data={"status": "Execution of previous code blocks is done."}),
-    ]
+    replay_task = asyncio.create_task(replay())
+    patch_registry({thread_id: []})
+    Registry[thread_id].mcp_manager = ToolMcpManager(tool_name)
+    Registry[thread_id].replay_task = replay_task
+    return release_replay, replay_task
 
 
 @pytest.mark.asyncio
 async def test_code_interpreter_waits_for_replay_before_mcp_call(
     patch_registry, patch_thread_storage, monkeypatch
 ):
-    release_replay = asyncio.Event()
+    release_replay, _ = set_replay_conversation(
+        patch_registry, "t-code", "code_interpreter"
+    )
     mcp_called = asyncio.Event()
-
-    async def replay():
-        await release_replay.wait()
-
-    replay_task = asyncio.create_task(replay())
-    patch_registry({"t-stream": []})
-    Registry["t-stream"].mcp_manager = CodeToolMcpManager()
-    Registry["t-stream"].replay_task = replay_task
 
     async def fake_acomplete(**kwargs):
         return fake_code_interpreter_stream()
@@ -122,7 +145,7 @@ async def test_code_interpreter_waits_for_replay_before_mcp_call(
 
     stream = stream_with_tools(
         model="test-model",
-        thread_id="t-stream",
+        thread_id="t-code",
         messages=[],
         acomplete_func=fake_acomplete,
         stream_state=StreamState(),
@@ -130,26 +153,108 @@ async def test_code_interpreter_waits_for_replay_before_mcp_call(
         store_thread=False,
     )
 
-    first = await anext(stream)
-    second = await anext(stream)
+    assert await anext(stream) == REPLAYING_HINT
+    assert isinstance(await anext(stream), SVCode)
 
-    assert isinstance(first, SVCode)
-    assert second == SVServerHint(data={"status": "Executing previous code blocks..."})
+    waiting_for_replay = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+
+    assert not waiting_for_replay.done()
     assert not mcp_called.is_set()
 
     release_replay.set()
 
-    seen_done_hint = False
+    assert await waiting_for_replay == REPLAY_DONE_HINT
+
     seen_code_output = False
     async for item in stream:
-        if item == SVServerHint(
-            data={"status": "Execution of previous code blocks is done."}
-        ):
-            seen_done_hint = True
         if isinstance(item, SVCodeOutput):
             seen_code_output = True
             break
 
-    assert seen_done_hint
     assert seen_code_output
     assert mcp_called.is_set()
+
+
+@pytest.mark.asyncio
+async def test_plain_answer_sends_replay_hints_without_blocking_answer(
+    patch_registry, patch_thread_storage
+):
+    release_replay, _ = set_replay_conversation(
+        patch_registry, "t-plain", "code_interpreter"
+    )
+
+    async def fake_acomplete(**kwargs):
+        return fake_plain_text_stream()
+
+    stream = stream_with_tools(
+        model="test-model",
+        thread_id="t-plain",
+        messages=[],
+        acomplete_func=fake_acomplete,
+        stream_state=StreamState(),
+        storage=patch_thread_storage,
+        store_thread=False,
+    )
+
+    assert await anext(stream) == REPLAYING_HINT
+    assert await anext(stream) == SVAssistant(text="plain answer")
+
+    waiting_for_done = asyncio.create_task(anext(stream))
+    await asyncio.sleep(0)
+
+    assert not waiting_for_done.done()
+
+    release_replay.set()
+
+    assert await waiting_for_done == REPLAY_DONE_HINT
+    assert isinstance(await anext(stream), SVStreamEnd)
+
+
+@pytest.mark.asyncio
+async def test_non_code_tool_does_not_wait_but_emits_done_when_replay_finishes(
+    patch_registry, patch_thread_storage, monkeypatch
+):
+    release_replay, replay_task = set_replay_conversation(
+        patch_registry, "t-web", "web_search"
+    )
+    mcp_called = asyncio.Event()
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(delay):
+        await original_sleep(0)
+
+    async def fake_acomplete(**kwargs):
+        return fake_web_search_stream()
+
+    async def fake_run_tool_via_mcp(**kwargs):
+        mcp_called.set()
+        release_replay.set()
+        await replay_task
+        return json.dumps({"structuredContent": {"result": "search result"}})
+
+    monkeypatch.setattr(orchestrator, "run_tool_via_mcp", fake_run_tool_via_mcp)
+    monkeypatch.setattr(orchestrator.asyncio, "sleep", fast_sleep)
+
+    stream = stream_with_tools(
+        model="test-model",
+        thread_id="t-web",
+        messages=[],
+        acomplete_func=fake_acomplete,
+        stream_state=StreamState(),
+        storage=patch_thread_storage,
+        store_thread=False,
+    )
+
+    assert await anext(stream) == REPLAYING_HINT
+    tool_call = await anext(stream)
+    assert tool_call.variant == "ToolCall"
+
+    done_hint = None
+    async for item in stream:
+        if item == REPLAY_DONE_HINT:
+            done_hint = item
+            break
+
+    assert mcp_called.is_set()
+    assert done_hint == REPLAY_DONE_HINT


### PR DESCRIPTION
In #69, this hint was implemented to be sent only when a new code-interpreter tool-call is triggered. 

With this PR, the behaviour is updated to include all other cases. If the incoming user request only triggers assistant response (plain text) or any other tool call than code-interpreter, the hint is sent but the execution is not blocked.