### PR TITLE
Refactor/stream variants

### DIFF
--- a/scripts/dev_chat.py
+++ b/scripts/dev_chat.py
@@ -109,7 +109,7 @@ async def _run_turn(
             storage=storage,
         ):
             if isinstance(variant, SVAssistant):
-                txt = getattr(variant, "text", "") or ""
+                txt = variant.content or ""
                 if first_chunk:
                     # Print a header once per assistant message
                     print("\nAssistant:", end=" ", flush=True)
@@ -118,7 +118,7 @@ async def _run_turn(
                 chunk_count += 1
                 char_count += len(txt)
             elif isinstance(variant, SVCode):
-                txt = getattr(variant, "code", "") or ""
+                txt = variant.content or ""
                 if first_chunk:
                     # Print a header once per code variant
                     print("\nCode:", end=" ", flush=True)

--- a/src/climateclaw/api/chatbot/getthread.py
+++ b/src/climateclaw/api/chatbot/getthread.py
@@ -34,9 +34,7 @@ def _post_process(variants: list[StreamVariant]) -> list[SVDict]:
     for i, v in enumerate(items):
         if isinstance(v, SVStreamEnd):
             is_last = i == len(items) - 1
-            if (not is_last) or (
-                "unexpected manner" in (getattr(v, "message", "") or "").lower()
-            ):
+            if (not is_last) or ("unexpected manner" in (v.content or "").lower()):
                 continue
         cleaned.append(from_sv_to_json(v))
     return cleaned

--- a/src/climateclaw/api/chatbot/streamresponse.py
+++ b/src/climateclaw/api/chatbot/streamresponse.py
@@ -236,7 +236,7 @@ async def streamresponse(
         try:
             if is_new_thread:
                 # Append ServerHint with thread_id
-                hint_v = SVServerHint(data={"thread_id": thread_id})
+                hint_v = SVServerHint(content={"thread_id": thread_id})
                 for data in _sse_data(from_sv_to_json(hint_v)):
                     yield data
                 await add_to_conversation(
@@ -269,7 +269,7 @@ async def streamresponse(
                         await cancel_tool_tasks(thread_id)
 
             if stop_requested:
-                end_v = SVStreamEnd(message="Stream is stopped by user.")
+                end_v = SVStreamEnd(content="Stream is stopped by user.")
                 for data in _sse_data(from_sv_to_json(end_v)):
                     yield data
                 await end_and_save_conversation(

--- a/src/climateclaw/core/heartbeat.py
+++ b/src/climateclaw/core/heartbeat.py
@@ -56,4 +56,4 @@ async def heartbeat_content():
     heartbeat["process_memory"] = process_memory
 
     # Return as StreamVariant::ServerHint
-    return SVServerHint(data=heartbeat)
+    return SVServerHint(content=heartbeat)

--- a/src/climateclaw/core/prompting.py
+++ b/src/climateclaw/core/prompting.py
@@ -7,10 +7,8 @@ from pathlib import Path
 from typing import Any, Literal
 
 from climateclaw.core.available_chatbots import model_is_gpt_5, model_is_ollama
-from climateclaw.services.streaming.stream_variants import (
-    help_convert_sv_ccrm,
-    parse_examples_jsonl,
-)
+from climateclaw.services.streaming.openai_helpers import help_convert_sv_ccrm
+from climateclaw.services.streaming.stream_variants import parse_examples_jsonl
 
 """
 Prompt loading & assembly (non-streaming), single API for all models.

--- a/src/climateclaw/services/mcp/mcp_manager.py
+++ b/src/climateclaw/services/mcp/mcp_manager.py
@@ -9,7 +9,7 @@ from climateclaw.core.settings import get_settings
 from climateclaw.services.authentication.auth import Authenticator
 from climateclaw.services.mcp.client import McpClient
 from climateclaw.services.storage.helpers import get_mongodb_uri
-from climateclaw.services.streaming.stream_variants import mcp_tool_to_openai_function
+from climateclaw.services.streaming.openai_helpers import mcp_tool_to_openai_function
 
 settings = get_settings()
 DEFAULT_LOGGER = configure_logging(__name__)

--- a/src/climateclaw/services/storage/mongodb_storage.py
+++ b/src/climateclaw/services/storage/mongodb_storage.py
@@ -354,7 +354,7 @@ def update_threadid_in_content(
     new_id: str, content: list[StreamVariant], logger
 ) -> list[StreamVariant]:
     if isinstance(content[0], SVServerHint):
-        content[0] = SVServerHint(data={"thread_id": new_id})
+        content[0] = SVServerHint(content={"thread_id": new_id})
         logger.info("Updated ServerHint with new thread-id.")
     else:
         if any(isinstance(c, SVServerHint) for c in content):
@@ -364,5 +364,5 @@ def update_threadid_in_content(
             logger.info(
                 "ServerHint is missing in the thread content. It is inserted with the new thread-id."
             )
-            content = [SVServerHint(data={"thread_id": new_id})] + content
+            content = [SVServerHint(content={"thread_id": new_id})] + content
     return content

--- a/src/climateclaw/services/storage/summarize_topic.py
+++ b/src/climateclaw/services/storage/summarize_topic.py
@@ -53,7 +53,7 @@ def _extract_first_meaningful_user_text(content: List[StreamVariant]) -> str:
     """Return the first non-empty user text that is not exact-match filler."""
     for sv in content:
         if isinstance(sv, SVUser):
-            text = _normalize_text(getattr(sv, "text", ""))
+            text = _normalize_text(sv.content)
             if text and not _is_low_information(text):
                 return text
     return ""

--- a/src/climateclaw/services/streaming/active_conversations.py
+++ b/src/climateclaw/services/streaming/active_conversations.py
@@ -256,9 +256,9 @@ async def _replay_code_history(thread_id: str) -> None:
 
     # Extract all code blocks in chronological order
     code_blocks: list[str] = [
-        v.code
+        v.content
         for v in messages
-        if isinstance(v, SVCode) and isinstance(v.code, str) and v.code.strip()
+        if isinstance(v, SVCode) and isinstance(v.content, str) and v.content.strip()
     ]
 
     log = configure_logging(__name__, thread_id=thread_id)

--- a/src/climateclaw/services/streaming/openai_helpers.py
+++ b/src/climateclaw/services/streaming/openai_helpers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from copy import deepcopy
 from typing import Any, Dict, List, Union, cast
 
 from typing_extensions import TypedDict
@@ -166,15 +165,7 @@ def help_convert_sv_ccrm(
             out.append(_tool_call_message(v.content, v.id, tool_name=TOOL_NAME_CODE))
 
         elif isinstance(v, SVCodeOutput):
-            code_result = deepcopy(v.content)
-            for file in code_result.get("created_files", []):
-                file.pop("preview_url", None)
-
-            out.append(
-                _tool_result_message(
-                    json.dumps(code_result), v.id, tool_name=TOOL_NAME_CODE
-                )
-            )
+            out.append(_tool_result_message(v.content, v.id, tool_name=TOOL_NAME_CODE))
 
         elif isinstance(v, SVToolCall):
             out.append(_tool_call_message(v.content, v.id, tool_name=v.tool_name))

--- a/src/climateclaw/services/streaming/openai_helpers.py
+++ b/src/climateclaw/services/streaming/openai_helpers.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from typing import Any, Dict, List, Union, cast
+
+from typing_extensions import TypedDict
+
+from climateclaw.core.logging_setup import configure_logging
+
+from .stream_variants import (
+    Conversation,
+    SVAssistant,
+    SVCode,
+    SVCodeOutput,
+    SVImage,
+    SVOpenAIError,
+    SVPrompt,
+    SVServerError,
+    SVServerHint,
+    SVStreamEnd,
+    SVToolCall,
+    SVToolOutput,
+    SVUser,
+    normalize_conv_for_prompt,
+)
+
+logger = configure_logging(__name__)
+
+
+# Roles (OpenAI Chat)
+ROLE_SYSTEM = "system"
+ROLE_USER = "user"
+ROLE_ASSISTANT = "assistant"
+ROLE_TOOL = "tool"
+
+# Conventions
+TOOL_NAME_CODE = "code_interpreter"
+
+
+class OpenAIMessage(TypedDict, total=False):
+    role: str
+    content: Any
+    name: str
+    tool_calls: list[dict]
+    tool_call_id: str  # for tool role
+
+
+def _as_system(content: Union[str, dict, list]) -> OpenAIMessage:
+    if not isinstance(content, str):
+        try:
+            content = json.dumps(content, ensure_ascii=False)
+        except Exception:
+            content = str(content)
+    return {"role": ROLE_SYSTEM, "content": content}
+
+
+def _tool_call_message(args: str, call_id: str, tool_name: str) -> OpenAIMessage:
+    # Arguments should be a JSON string per OpenAI function-call schema.
+    return {
+        "role": ROLE_ASSISTANT,
+        "content": None,
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": tool_name, "arguments": args},
+            }
+        ],
+    }
+
+
+def _tool_result_message(output: str, call_id: str, tool_name: str) -> OpenAIMessage:
+    return {
+        "role": ROLE_TOOL,
+        "name": tool_name,
+        "tool_call_id": call_id,
+        "content": output,
+    }
+
+
+def _image_user_message(b64: str, mime: str) -> OpenAIMessage:
+    return {
+        "role": ROLE_USER,
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{b64}"},
+            }
+        ],
+    }
+
+
+def mcp_tool_to_openai_function(tool: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Convert an MCP tool descriptor to OpenAI-style tool schema:
+    MCP (typical):
+      {"name": "search", "description": "...", "input_schema": {...}}
+    OpenAI tool:
+      {"type":"function","function":{"name":"search","description":"...","parameters":{...}}}
+    Be permissive: fall back to {} if schema missing.
+    """
+    name = tool.get("name") or ""
+    desc = tool.get("description") or ""
+    params = tool.get("input_schema") or tool.get("parameters") or {}
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": desc,
+            "parameters": params if isinstance(params, dict) else {},
+        },
+    }
+
+
+def _extend_with_prompt_json(out: List[OpenAIMessage], json_str: str) -> None:
+    try:
+        data = json.loads(json_str)
+    except Exception as e:
+        logger.warning(
+            "Failed to parse Prompt JSON payload: %s; skipping this Prompt variant.", e
+        )
+        return
+
+    if not isinstance(data, list):
+        logger.warning("Prompt payload is not a list; skipping.")
+        return
+
+    for i, msg in enumerate(data):
+        if not isinstance(msg, dict):
+            logger.warning("Prompt message[%d] is not an object; skipping.", i)
+            continue
+        role = msg.get("role")
+        if role not in (ROLE_SYSTEM, ROLE_USER, ROLE_ASSISTANT, ROLE_TOOL):
+            logger.warning("Prompt message[%d] has invalid role=%r; skipping.", i, role)
+            continue
+        out.append(
+            cast(OpenAIMessage, msg)
+        )  # trust caller for deeper schema (tool_calls etc.)
+
+
+def help_convert_sv_ccrm(
+    conversation: Conversation,
+    include_images: bool = False,
+    include_meta: bool = False,
+) -> List[OpenAIMessage]:
+    """
+    Convert a StreamVariant conversation to OpenAI ChatCompletion messages.
+    • include_images: whether to include Image variants (Rust passes false for prompting)
+    • include_meta: whether to include ServerHint/Errors/StreamEnd as system/tool messages
+    """
+    conv = normalize_conv_for_prompt(conversation, include_meta=include_meta)
+    out: List[OpenAIMessage] = []
+
+    for v in conv:
+        if isinstance(v, SVPrompt):
+            _extend_with_prompt_json(out, v.content)
+
+        elif isinstance(v, SVUser):
+            out.append({"role": ROLE_USER, "content": v.content})
+
+        elif isinstance(v, SVAssistant):
+            out.append({"role": ROLE_ASSISTANT, "content": v.content})
+
+        elif isinstance(v, SVCode):
+            out.append(_tool_call_message(v.content, v.id, tool_name=TOOL_NAME_CODE))
+
+        elif isinstance(v, SVCodeOutput):
+            code_result = deepcopy(v.content)
+            for file in code_result.get("created_files", []):
+                file.pop("preview_url", None)
+
+            out.append(
+                _tool_result_message(
+                    json.dumps(code_result), v.id, tool_name=TOOL_NAME_CODE
+                )
+            )
+
+        elif isinstance(v, SVToolCall):
+            out.append(_tool_call_message(v.content, v.id, tool_name=v.tool_name))
+
+        elif isinstance(v, SVToolOutput):
+            out.append(_tool_result_message(v.content, v.id, tool_name=v.tool_name))
+
+        elif isinstance(v, SVImage):
+            if include_images:
+                out.append(_image_user_message(v.content, v.mime))
+            else:
+                logger.debug("Dropping Image variant in prompt (include_images=False).")
+
+        elif isinstance(v, SVServerHint):
+            if include_meta:
+                out.append(_as_system(v.content))
+
+        elif isinstance(v, SVServerError):
+            if include_meta:
+                out.append(_as_system(v.content))
+
+        elif isinstance(v, SVOpenAIError):
+            if include_meta:
+                out.append(_as_system(v.content))
+
+        elif isinstance(v, SVStreamEnd):
+            if include_meta:
+                out.append(_as_system(v.content))
+
+        else:
+            logger.warning("Unknown StreamVariant encountered: %r", v)
+
+    return out

--- a/src/climateclaw/services/streaming/replay_gate.py
+++ b/src/climateclaw/services/streaming/replay_gate.py
@@ -18,14 +18,14 @@ class ReplayGate:
             return None
 
         self.start_sent = True
-        return SVServerHint(data={"status": REPLAYING_CODE_STATUS})
+        return SVServerHint(content={"status": REPLAYING_CODE_STATUS})
 
     def done_hint_if_ready(self) -> SVServerHint | None:
         if self.done_sent or self.task is None or not self.task.done():
             return None
 
         self.done_sent = True
-        return SVServerHint(data={"status": REPLAY_DONE_STATUS})
+        return SVServerHint(content={"status": REPLAY_DONE_STATUS})
 
     async def wait_done_hint(self) -> SVServerHint | None:
         if self.done_sent or self.task is None:
@@ -35,4 +35,4 @@ class ReplayGate:
             await self.task
 
         self.done_sent = True
-        return SVServerHint(data={"status": REPLAY_DONE_STATUS})
+        return SVServerHint(content={"status": REPLAY_DONE_STATUS})

--- a/src/climateclaw/services/streaming/stream_orchestrator.py
+++ b/src/climateclaw/services/streaming/stream_orchestrator.py
@@ -23,9 +23,12 @@ from climateclaw.services.streaming.active_conversations import (
     unregister_tool_task,
 )
 from climateclaw.services.streaming.litellm_client import acomplete, first_text
+from climateclaw.services.streaming.openai_helpers import (
+    OpenAIMessage,
+    help_convert_sv_ccrm,
+)
 from climateclaw.services.streaming.replay_gate import ReplayGate
 from climateclaw.services.streaming.stream_variants import (
-    OpenAIMessage,
     StreamVariant,
     SVAssistant,
     SVCode,
@@ -35,7 +38,6 @@ from climateclaw.services.streaming.stream_variants import (
     SVToolCall,
     SVUser,
     from_json_to_sv,
-    help_convert_sv_ccrm,
 )
 from climateclaw.services.streaming.tool_calls import (
     FinalSummary,
@@ -115,7 +117,7 @@ async def stream_with_tools(
             piece = delta.get("content") or ""
             if piece:
                 accumulated_asst_text.append(piece)
-                yield SVAssistant(text=piece)
+                yield SVAssistant(content=piece)
 
             # tool call: stream code chunks live and accumulate deltas
             tc_list = delta.get("tool_calls") or []
@@ -132,7 +134,7 @@ async def stream_with_tools(
                     args_chunk = fn.get("arguments", "")
                     if args_chunk and tool_name == "code_interpreter":
                         # stream arguments chunk immediately
-                        yield SVCode(code=args_chunk, id=call_id)
+                        yield SVCode(content=args_chunk, id=call_id)
 
             #  end-of-message
             if choice.get("finish_reason"):
@@ -142,13 +144,13 @@ async def stream_with_tools(
         for p in re.findall(r"\S+\s*", full_txt):
             if p:
                 accumulated_asst_text.append(full_txt)
-                yield SVAssistant(text=full_txt)
+                yield SVAssistant(content=full_txt)
 
     # 2) Any tool calls?
     tool_calls = finalize_tool_calls(tool_agg)
 
     if accumulated_asst_text:
-        asst_v = SVAssistant(text="".join(accumulated_asst_text))
+        asst_v = SVAssistant(content="".join(accumulated_asst_text))
         await add_to_conversation(
             thread_id, [asst_v], storage=storage, store_thread=store_thread
         )
@@ -158,7 +160,7 @@ async def stream_with_tools(
         if hint := await stream_state.replay_gate.wait_done_hint():
             yield hint
 
-        end_v = SVStreamEnd(message="Stream ended.")
+        end_v = SVStreamEnd(content="Stream ended.")
         yield end_v
         stream_state.finished = True
         return
@@ -176,9 +178,9 @@ async def stream_with_tools(
                 yield hint
 
             # accumulated code text to be appended to thread
-            tool_v = SVCode(code=args_txt, id=id)
+            tool_v = SVCode(content=args_txt, id=id)
         else:
-            tool_v = SVToolCall(arg=args_txt, id=id, tool_name=name)  # type: ignore[assignment]
+            tool_v = SVToolCall(content=args_txt, id=id, tool_name=name)  # type: ignore[assignment]
             # code is already streamed, we stream the other tool calls here too
             yield tool_v
 
@@ -330,7 +332,7 @@ async def run_stream(
     log = logger or DEFAULT_LOGGER
 
     # Append user content
-    user_v = SVUser(text=user_input or "")
+    user_v = SVUser(content=user_input or "")
     await add_to_conversation(
         thread_id, [user_v], storage=storage, store_thread=store_thread
     )
@@ -386,8 +388,8 @@ async def run_stream(
             stream_state.finished = True
         except Exception as e:
             log.exception("Stream error: %s", e)
-            err_v = SVServerError(message=str(e))
-            end_v = SVStreamEnd(message="Stream ended with an error.")
+            err_v = SVServerError(content=str(e))
+            end_v = SVStreamEnd(content="Stream ended with an error.")
             await add_to_conversation(
                 thread_id, [err_v], storage=storage, store_thread=store_thread
             )

--- a/src/climateclaw/services/streaming/stream_variants.py
+++ b/src/climateclaw/services/streaming/stream_variants.py
@@ -1,25 +1,26 @@
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import TypedDict
+
+from climateclaw.core.logging_setup import configure_logging
 
 """
 • Class-based StreamVariant models (discriminator: `variant`)
 • Conversation utilities: cleanup_conversation(), normalize_conv_for_prompt()
-• Conversion to OpenAI Chat messages: help_convert_sv_ccrm(...)
 • Json <-> class conversion helpers: from_json_to_sv(), from_sv_to_json(), parse_examples_jsonl()
 
 Notes
 -----
 • examples.jsonl is stored in wire shape; use parse_examples_jsonl(...) to read it as classes.
+• Pydantic model fields intentionally match the wire/json shape:
+    {"variant": "...", "content": ..., ...}
 """
 
-logger = logging.getLogger(__name__)
+logger = configure_logging(__name__)
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Constants / Conventions
@@ -36,19 +37,8 @@ TOOL_OUTPUT = "ToolOutput"
 IMAGE = "Image"
 SERVER_ERROR = "ServerError"
 OPENAI_ERROR = "OpenAIError"
-CODE_ERROR = "CodeError"
 STREAM_END = "StreamEnd"
 SERVER_HINT = "ServerHint"
-
-# Roles (OpenAI Chat)
-ROLE_SYSTEM = "system"
-ROLE_USER = "user"
-ROLE_ASSISTANT = "assistant"
-ROLE_TOOL = "tool"
-
-# Conventions
-ASSISTANT_NAME = "ClimateClaw"
-TOOL_NAME_CODE = "code_interpreter"
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -63,81 +53,73 @@ class _SVBase(BaseModel):
 
 
 class SVPrompt(_SVBase):
-    # IMPORTANT: use string literals inside Literal[...] to satisfy type-checkers
     variant: Literal["Prompt"] = Field(default="Prompt")
-    # JSON string representing a list of chat messages (OpenAI format).
-    payload: str = Field(..., description="JSON string of ChatCompletion messages")
+    content: str = Field(..., description="JSON string of ChatCompletion messages")
 
 
 class SVUser(_SVBase):
     variant: Literal["User"] = Field(default="User")
-    text: str
+    content: str
 
 
 class SVAssistant(_SVBase):
     variant: Literal["Assistant"] = Field(default="Assistant")
-    text: str
-    name: str = Field(default=ASSISTANT_NAME, description="Assistant display name")
+    content: str
     feedback: str = Field(default="", description="User feedback")
 
 
 class SVCode(_SVBase):
     variant: Literal["Code"] = Field(default="Code")
-    code: str
+    content: str
     id: str
     feedback: str = Field(default="", description="User feedback")
 
 
 class SVCodeOutput(_SVBase):
     variant: Literal["CodeOutput"] = Field(default="CodeOutput")
-    output: str
+    content: str
     id: str
 
 
 class SVImage(_SVBase):
     variant: Literal["Image"] = Field(default="Image")
-    b64: str
+    content: str
     id: str
     mime: str = Field(default="image/png")
 
 
 class SVToolCall(_SVBase):
     variant: Literal["ToolCall"] = Field(default="ToolCall")
-    arg: str
+    content: str
     tool_name: str
     id: str
 
 
 class SVToolOutput(_SVBase):
     variant: Literal["ToolOutput"] = Field(default="ToolOutput")
-    output: str
+    content: str
     tool_name: str
     id: str
 
 
 class SVServerHint(_SVBase):
     variant: Literal["ServerHint"] = Field(default="ServerHint")
-    data: dict | str
+    content: dict | str
 
 
 class SVServerError(_SVBase):
     variant: Literal["ServerError"] = Field(default="ServerError")
-    message: str
+    content: str
 
 
 class SVOpenAIError(_SVBase):
     variant: Literal["OpenAIError"] = Field(default="OpenAIError")
-    message: str
-
-
-class SVCodeError(_SVBase):
-    variant: Literal["CodeError"] = Field(default="CodeError")
-    message: str
+    content: str
 
 
 class SVStreamEnd(_SVBase):
     variant: Literal["StreamEnd"] = Field(default="StreamEnd")
-    message: str
+    content: str
 
 
 # Discriminated union type for parsing
@@ -153,7 +135,6 @@ StreamVariant = Annotated[
     | SVServerHint
     | SVServerError
     | SVOpenAIError
-    | SVCodeError
     | SVStreamEnd,
     Field(discriminator="variant"),
 ]
@@ -173,8 +154,7 @@ def cleanup_conversation(
     conv: Conversation, append_stream_end: bool = False
 ) -> Conversation:
     """
-    Insert missing CodeOutput after Code and ensure StreamEnd at the end.
-    Mirrors the spirit of Rust's cleanup_conversation with class-based variants.
+    Insert missing CodeOutput after Code and optionally ensure StreamEnd at the end.
     """
     out: Conversation = []
     pending_code_id: str | None = None
@@ -185,7 +165,7 @@ def cleanup_conversation(
         if pending_code_id is not None and not isinstance(v, SVCodeOutput):
             out.append(
                 SVCodeOutput(
-                    output="No response was received from code-interpreter.",
+                    content="No response was received from code-interpreter.",
                     id=pending_code_id,
                 )
             )
@@ -208,7 +188,7 @@ def cleanup_conversation(
         # close dangling code with an empty output
         out.append(
             SVCodeOutput(
-                output="No response was received from code-interpreter.",
+                content="No response was received from code-interpreter.",
                 id=pending_code_id,
             )
         )
@@ -216,7 +196,7 @@ def cleanup_conversation(
     # Ensure ends with StreamEnd (only if requested)
     if append_stream_end:
         if not out or not isinstance(out[-1], SVStreamEnd):
-            out.append(SVStreamEnd(message="Stream ended in a very unexpected manner"))
+            out.append(SVStreamEnd(content="Stream ended in a very unexpected manner"))
 
     return out
 
@@ -235,9 +215,7 @@ def normalize_conv_for_prompt(
 
     filtered: Conversation = []
     for v in conv:
-        if isinstance(
-            v, (SVServerHint, SVServerError, SVOpenAIError, SVCodeError, SVStreamEnd)
-        ):
+        if isinstance(v, (SVServerHint, SVServerError, SVOpenAIError, SVStreamEnd)):
             # Drop meta if include_meta=False (Rust-like behavior)
             continue
         filtered.append(v)
@@ -245,217 +223,42 @@ def normalize_conv_for_prompt(
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Conversion to OpenAI Chat messages
-# ──────────────────────────────────────────────────────────────────────────────
-
-
-class OpenAIMessage(TypedDict, total=False):
-    role: str
-    content: Any
-    name: str
-    tool_calls: list[dict]
-    tool_call_id: str  # for tool role
-
-
-def _as_system(name: str, content: str | dict | list) -> OpenAIMessage:
-    if not isinstance(content, str):
-        try:
-            content = json.dumps(content, ensure_ascii=False)
-        except Exception:
-            content = str(content)
-    return {"role": ROLE_SYSTEM, "name": name, "content": content}
-
-
-def _tool_call_message(args: str, call_id: str, tool_name: str) -> OpenAIMessage:
-    # Arguments should be a JSON string per OpenAI function-call schema.
-    return {
-        "role": ROLE_ASSISTANT,
-        "name": ASSISTANT_NAME,
-        "content": None,
-        "tool_calls": [
-            {
-                "id": call_id,
-                "type": "function",
-                "function": {"name": tool_name, "arguments": args},
-            }
-        ],
-    }
-
-
-def _tool_result_message(output: str, call_id: str, tool_name: str) -> OpenAIMessage:
-    return {
-        "role": ROLE_TOOL,
-        "name": tool_name,
-        "tool_call_id": call_id,
-        "content": output,
-    }
-
-
-def _image_user_message(b64: str, mime: str) -> OpenAIMessage:
-    return {
-        "role": ROLE_USER,
-        "content": [
-            {
-                "type": "image_url",
-                "image_url": {"url": f"data:{mime};base64,{b64}"},
-            }
-        ],
-    }
-
-
-def mcp_tool_to_openai_function(tool: dict[str, Any]) -> dict[str, Any]:
-    """
-    Convert an MCP tool descriptor to OpenAI-style tool schema:
-    MCP (typical):
-      {"name": "search", "description": "...", "input_schema": {...}}
-    OpenAI tool:
-      {"type":"function","function":{"name":"search","description":"...","parameters":{...}}}
-    Be permissive: fall back to {} if schema missing.
-    """
-    name = tool.get("name") or ""
-    desc = tool.get("description") or ""
-    params = tool.get("input_schema") or tool.get("parameters") or {}
-    return {
-        "type": "function",
-        "function": {
-            "name": name,
-            "description": desc,
-            "parameters": params if isinstance(params, dict) else {},
-        },
-    }
-
-
-def _extend_with_prompt_json(out: list[OpenAIMessage], json_str: str) -> None:
-    try:
-        data = json.loads(json_str)
-    except Exception as e:
-        logger.warning(
-            "Failed to parse Prompt JSON payload: %s; skipping this Prompt variant.", e
-        )
-        return
-
-    if not isinstance(data, list):
-        logger.warning("Prompt payload is not a list; skipping.")
-        return
-
-    for i, msg in enumerate(data):
-        if not isinstance(msg, dict):
-            logger.warning("Prompt message[%d] is not an object; skipping.", i)
-            continue
-        role = msg.get("role")
-        if role not in (ROLE_SYSTEM, ROLE_USER, ROLE_ASSISTANT, ROLE_TOOL):
-            logger.warning("Prompt message[%d] has invalid role=%r; skipping.", i, role)
-            continue
-        out.append(msg)  # type: ignore[arg-type] # trust caller for deeper schema (tool_calls etc.)
-
-
-def help_convert_sv_ccrm(
-    conversation: Conversation,
-    include_images: bool = False,
-    include_meta: bool = False,
-) -> list[OpenAIMessage]:
-    """
-    Convert a StreamVariant conversation to OpenAI ChatCompletion messages.
-    • include_images: whether to include Image variants (Rust passes false for prompting)
-    • include_meta: whether to include ServerHint/Errors/StreamEnd as system/tool messages
-    """
-    conv = normalize_conv_for_prompt(conversation, include_meta=include_meta)
-    out: list[OpenAIMessage] = []
-
-    for v in conv:
-        if isinstance(v, SVPrompt):
-            _extend_with_prompt_json(out, v.payload)
-
-        elif isinstance(v, SVUser):
-            out.append({"role": ROLE_USER, "content": v.text})
-
-        elif isinstance(v, SVAssistant):
-            out.append({"role": ROLE_ASSISTANT, "name": v.name, "content": v.text})
-
-        elif isinstance(v, SVCode):
-            out.append(_tool_call_message(v.code, v.id, tool_name=TOOL_NAME_CODE))
-
-        elif isinstance(v, SVCodeOutput):
-            out.append(_tool_result_message(v.output, v.id, tool_name=TOOL_NAME_CODE))
-
-        elif isinstance(v, SVToolCall):
-            out.append(_tool_call_message(v.arg, v.id, tool_name=v.tool_name))
-
-        elif isinstance(v, SVToolOutput):
-            out.append(_tool_result_message(v.output, v.id, tool_name=v.tool_name))
-
-        elif isinstance(v, SVImage):
-            if include_images:
-                out.append(_image_user_message(v.b64, v.mime))
-            else:
-                logger.debug("Dropping Image variant in prompt (include_images=False).")
-
-        elif isinstance(v, SVServerHint):
-            if include_meta:
-                out.append(_as_system("server_hint", v.data))
-
-        elif isinstance(v, SVServerError):
-            if include_meta:
-                out.append(_as_system("server_error", v.message))
-
-        elif isinstance(v, SVOpenAIError):
-            if include_meta:
-                out.append(_as_system("openai_error", v.message))
-
-        elif isinstance(v, SVCodeError):
-            # Code Errors do not have IDs, so we treat them as system messages rather than tool results.
-            if include_meta:
-                out.append(_as_system("code_error", v.message))
-
-        elif isinstance(v, SVStreamEnd):
-            if include_meta:
-                out.append(_as_system("stream_end", v.message))
-
-        else:
-            logger.warning("Unknown StreamVariant encountered: %r", v)
-
-    return out
-
-
-# ──────────────────────────────────────────────────────────────────────────────
 # JSON <-> Stream Variant class conversion + examples loader
 # ──────────────────────────────────────────────────────────────────────────────
+
+
+def _as_str(value: Any) -> str:
+    return "" if value is None else str(value)
 
 
 def from_json_to_sv(obj: dict) -> StreamVariant:
     """
     Convert a json/dict into class-based StreamVariant.
-    Json examples:
-      {"variant":"Assistant","content":"..."}
-      {"variant":"User","content":"..."}
-      {"variant":"Code","content":"...", "id": "call_ABC"}
-      {"variant":"CodeOutput","content":"...", "id": "call_ABC"}
-      {"variant":"Image","content":"..."}
+
+    This is the compatibility boundary. It accepts both current wire shape and
+    older examples.jsonl shapes, then returns normalized Pydantic variants whose
+    fields match the wire shape.
     """
     v = obj.get("variant")
     c = obj.get("content", "")
-    f = obj.get("feedback")
+    f = obj.get("feedback", "")
 
     if v == ASSISTANT:
-        return SVAssistant(
-            text="" if c is None else str(c), feedback="" if f is None else str(f)
-        )
+        return SVAssistant(content=_as_str(c), feedback=f)
     if v == USER:
-        return SVUser(text="" if c is None else str(c))
+        return SVUser(content=_as_str(c))
     if v == PROMPT:
-        return SVPrompt(payload="" if c is None else str(c))
+        return SVPrompt(content=_as_str(c))
     if v == SERVER_HINT:
-        return SVServerHint(data=c if isinstance(c, dict) else json.loads(c))
+        return SVServerHint(content=c if isinstance(c, dict) else json.loads(c))
     if v == SERVER_ERROR:
-        return SVServerError(message="" if c is None else str(c))
-    if v == CODE_ERROR:
-        return SVCodeError(message="" if c is None else str(c))
+        return SVServerError(content=_as_str(c))
     if v == OPENAI_ERROR:
-        return SVOpenAIError(message="" if c is None else str(c))
+        return SVOpenAIError(content=_as_str(c))
     if v == STREAM_END:
-        return SVStreamEnd(message="" if c is None else str(c))
+        return SVStreamEnd(content=_as_str(c))
     if v == IMAGE:
-        return SVImage(b64="" if c is None else str(c), id=obj.get("id", ""))
+        return SVImage(content=_as_str(c), id=_as_str(obj.get("id")))
 
     if v == CODE:
         code_text, id = "", ""
@@ -475,7 +278,7 @@ def from_json_to_sv(obj: dict) -> StreamVariant:
         else:
             code_text = str(c)
             id = obj.get("id", "")
-        return SVCode(code=code_text, id=str(id), feedback="" if f is None else str(f))
+        return SVCode(content=code_text, id=str(id), feedback=f)
 
     if v == CODE_OUTPUT:
         if (
@@ -485,81 +288,30 @@ def from_json_to_sv(obj: dict) -> StreamVariant:
         else:
             output = c
             id = obj.get("id", "")
-        return SVCodeOutput(output=str(output), id=str(id))
+        return SVCodeOutput(content=str(output), id=str(id))
 
     if v == TOOL_CALL:
-        arg = c
-        id = obj.get("id", "")
-        tool_name = obj.get("tool_name", "")
-        return SVToolCall(arg=str(arg), id=str(id), tool_name=tool_name)
+        return SVToolCall(
+            content=_as_str(c),
+            id=_as_str(obj.get("id")),
+            tool_name=_as_str(obj.get("tool_name")),
+        )
 
     if v == TOOL_OUTPUT or v == TOOL_CALL:
-        output = c
-        id = obj.get("id", "")
-        tool_name = obj.get("tool_name", "")
-        return SVToolOutput(output=str(output), id=str(id), tool_name=tool_name)
+        return SVToolOutput(
+            content=_as_str(c),
+            id=_as_str(obj.get("id")),
+            tool_name=_as_str(obj.get("tool_name")),
+        )
 
     raise ValueError(f"unsupported variant: {obj!r}")
 
 
 def from_sv_to_json(v: StreamVariant) -> SVDict:
     """
-    Convert Pydantic class back to json/dict.
+    Convert Pydantic StreamVariant back to json/dict.
     """
-    d = v.model_dump()
-    kind = d["variant"]
-    if kind == USER:
-        return {"variant": USER, "content": d["text"]}
-    if kind == ASSISTANT:
-        if d.get("feedback"):
-            return {
-                "variant": ASSISTANT,
-                "content": d["text"],
-                "feedback": d.get("feedback"),
-            }
-        else:
-            return {"variant": ASSISTANT, "content": d["text"]}
-    if kind == PROMPT:
-        return {"variant": PROMPT, "content": d["payload"]}
-    if kind == SERVER_HINT:
-        return {"variant": SERVER_HINT, "content": d["data"]}
-    if kind == SERVER_ERROR:
-        return {"variant": SERVER_ERROR, "content": d["message"]}
-    if kind == CODE_ERROR:
-        return {"variant": CODE_ERROR, "content": [d["message"]]}
-    if kind == OPENAI_ERROR:
-        return {"variant": OPENAI_ERROR, "content": d["message"]}
-    if kind == STREAM_END:
-        return {"variant": STREAM_END, "content": d["message"]}
-    if kind == IMAGE:
-        return {"variant": IMAGE, "content": d["b64"], "id": d["id"]}
-    if kind == CODE:
-        if d.get("feedback"):
-            return {
-                "variant": CODE,
-                "content": d["code"],
-                "id": d["id"],
-                "feedback": d.get("feedback", ""),
-            }
-        else:
-            return {"variant": CODE, "content": d["code"], "id": d["id"]}
-    if kind == CODE_OUTPUT:
-        return {"variant": CODE_OUTPUT, "content": d["output"], "id": d["id"]}
-    if kind == TOOL_CALL:
-        return {
-            "variant": TOOL_CALL,
-            "content": d["arg"],
-            "tool_name": d["tool_name"],
-            "id": d["id"],
-        }
-    if kind == TOOL_OUTPUT:
-        return {
-            "variant": TOOL_OUTPUT,
-            "content": d["output"],
-            "tool_name": d["tool_name"],
-            "id": d["id"],
-        }
-    return d
+    return v.model_dump(exclude_none=True)
 
 
 def parse_examples_jsonl(path: str | Path) -> list[StreamVariant]:
@@ -568,23 +320,29 @@ def parse_examples_jsonl(path: str | Path) -> list[StreamVariant]:
     """
     out: list[StreamVariant] = []
     p = Path(path)
+
     if not p.exists():
         return out
+
     for raw in p.read_text(encoding="utf-8", errors="ignore").splitlines():
         line = raw.strip()
+
         if not line or line.startswith("//"):
             continue
+
         try:
             obj = json.loads(line)
         except Exception:
             # keep quiet but skip — examples may include comments / non-json lines
             continue
+
         if isinstance(obj, dict) and "variant" in obj:
             try:
                 out.append(from_json_to_sv(obj))
             except Exception:
                 # skip unparseable lines
                 continue
+
     return out
 
 
@@ -640,7 +398,6 @@ __all__ = [
     "SVServerHint",
     "SVServerError",
     "SVOpenAIError",
-    "SVCodeError",
     "SVStreamEnd",
     # Constants / roles
     "PROMPT",
@@ -651,19 +408,11 @@ __all__ = [
     "IMAGE",
     "SERVER_ERROR",
     "OPENAI_ERROR",
-    "CODE_ERROR",
     "STREAM_END",
     "SERVER_HINT",
-    "ROLE_SYSTEM",
-    "ROLE_USER",
-    "ROLE_ASSISTANT",
-    "ROLE_TOOL",
-    "ASSISTANT_NAME",
-    "TOOL_NAME_CODE",
     # Functions
     "cleanup_conversation",
     "normalize_conv_for_prompt",
-    "help_convert_sv_ccrm",
     "is_prompt",
     "from_json_to_sv",
     "from_sv_to_json",

--- a/src/climateclaw/services/streaming/tool_calls.py
+++ b/src/climateclaw/services/streaming/tool_calls.py
@@ -6,14 +6,16 @@ from typing import Any
 
 from climateclaw.core.logging_setup import configure_logging
 from climateclaw.services.service_factory import McpManager
-from climateclaw.services.streaming.stream_variants import (
+from climateclaw.services.streaming.openai_helpers import (
     OpenAIMessage,
+    help_convert_sv_ccrm,
+)
+from climateclaw.services.streaming.stream_variants import (
     StreamVariant,
     SVCodeOutput,
     SVImage,
     SVToolOutput,
     SVUser,
-    help_convert_sv_ccrm,
 )
 
 DEFAULT_LOGGER = configure_logging(__name__)
@@ -128,9 +130,9 @@ def parse_tool_result(resp_txt: str, tool_name: str, call_id: str):
         out_msg = f"{tool_name} error: {out}"
 
         if tool_name == "code_interpreter":
-            toolout_v = SVCodeOutput(output=out_msg, id=call_id)
+            toolout_v = SVCodeOutput(content=out_msg, id=call_id)
         else:
-            toolout_v = SVToolOutput(output=out_msg, tool_name=tool_name, id=call_id)  # type: ignore[assignment]
+            toolout_v = SVToolOutput(content=out_msg, tool_name=tool_name, id=call_id)  # type: ignore[assignment]
         yield toolout_v
         tool_msg = help_convert_sv_ccrm([toolout_v])
         isError = True
@@ -159,7 +161,7 @@ def parse_code_interpreter_result(result: dict, id: str):
     else:
         codeout = ""  # We must send something here, the model expects it.
 
-    codeout_v = SVCodeOutput(output=codeout, id=id)
+    codeout_v = SVCodeOutput(content=codeout, id=id)
     yield codeout_v
     code_block.append(codeout_v)
     code_msgs.extend(help_convert_sv_ccrm([codeout_v]))
@@ -169,14 +171,14 @@ def parse_code_interpreter_result(result: dict, id: str):
         if "image/png" in r.keys():
             base64_image = r["image/png"]
             image_id = id + f"_{i}"
-            image_v = SVImage(b64=base64_image, id=image_id)
+            image_v = SVImage(content=base64_image, id=image_id)
             yield image_v
             code_block.append(image_v)
             code_msgs.extend(
                 help_convert_sv_ccrm(
                     [
                         SVUser(
-                            text="Here is the image returned by the Code Interpreter."
+                            content="Here is the image returned by the Code Interpreter."
                         ),
                         image_v,
                     ],
@@ -185,7 +187,7 @@ def parse_code_interpreter_result(result: dict, id: str):
             )
 
         if "application/json" in r.keys():
-            json_v = SVCodeOutput(output=r["application/json"], id=f"{id}:json")
+            json_v = SVCodeOutput(content=r["application/json"], id=f"{id}:json")
             yield json_v
             code_block.append(json_v)
             code_msgs.extend(help_convert_sv_ccrm([json_v]))
@@ -200,6 +202,6 @@ def parse_generic_tool_result(result: dict, tool_name: str, id: str, logger=None
         out = result.get("error", "")
     else:
         out = "Unknown response."
-    web_sv = SVToolOutput(output=out, tool_name=tool_name, id=id)
+    web_sv = SVToolOutput(content=out, tool_name=tool_name, id=id)
     web_msg = help_convert_sv_ccrm([web_sv])
     yield FinalSummary(var_block=[web_sv], tool_messages=web_msg, is_error=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -326,8 +326,8 @@ def patch_stream(monkeypatch):
             SVServerHint,
         )
 
-        yield SVServerHint(data={"thread_id": "t-abc"})
-        yield SVAssistant(text="hello")
+        yield SVServerHint(content={"thread_id": "t-abc"})
+        yield SVAssistant(content="hello")
         return
 
     monkeypatch.setattr(

--- a/tests/unit_tests/test_replay_queue.py
+++ b/tests/unit_tests/test_replay_queue.py
@@ -22,8 +22,8 @@ from climateclaw.services.streaming.stream_variants import (
 )
 from conftest import DummyMcpManager
 
-REPLAYING_HINT = SVServerHint(data={"status": REPLAYING_CODE_STATUS})
-REPLAY_DONE_HINT = SVServerHint(data={"status": REPLAY_DONE_STATUS})
+REPLAYING_HINT = SVServerHint(content={"status": REPLAYING_CODE_STATUS})
+REPLAY_DONE_HINT = SVServerHint(content={"status": REPLAY_DONE_STATUS})
 
 
 class ToolMcpManager(DummyMcpManager):
@@ -198,7 +198,7 @@ async def test_plain_answer_sends_replay_hints_without_blocking_answer(
     )
 
     assert await anext(stream) == REPLAYING_HINT
-    assert await anext(stream) == SVAssistant(text="plain answer")
+    assert await anext(stream) == SVAssistant(content="plain answer")
 
     waiting_for_done = asyncio.create_task(anext(stream))
     await asyncio.sleep(0)

--- a/tests/unit_tests/test_stream_variants.py
+++ b/tests/unit_tests/test_stream_variants.py
@@ -1,3 +1,4 @@
+from climateclaw.services.streaming.openai_helpers import help_convert_sv_ccrm
 from climateclaw.services.streaming.stream_variants import (
     StreamVariant,
     SVAssistant,
@@ -10,15 +11,14 @@ from climateclaw.services.streaming.stream_variants import (
     cleanup_conversation,
     from_json_to_sv,
     from_sv_to_json,
-    help_convert_sv_ccrm,
     normalize_conv_for_prompt,
 )
 
 
 def test_cleanup_inserts_codeoutput_and_end():
     conv: list[StreamVariant] = [
-        SVUser(text="hi"),
-        SVCode(code="print(1)", id="call_1"),
+        SVUser(content="hi"),
+        SVCode(content="print(1)", id="call_1"),
     ]
     out = cleanup_conversation(
         conv, append_stream_end=True
@@ -29,15 +29,15 @@ def test_cleanup_inserts_codeoutput_and_end():
     assert kinds == ["User", "Code", "CodeOutput", "StreamEnd"]
     assert isinstance(out[2], SVCodeOutput)
     assert out[2].id == "call_1"
-    assert out[2].output == "No response was received from code-interpreter."
+    assert out[2].content == "No response was received from code-interpreter."
 
 
 def test_cleanup_no_extra_end_if_existing():
     conv: list[StreamVariant] = [
-        SVUser(text="hi"),
-        SVCode(code="print(1)", id="call_1"),
-        SVCodeOutput(output="1", id="call_1"),
-        SVStreamEnd(message="Done"),
+        SVUser(content="hi"),
+        SVCode(content="print(1)", id="call_1"),
+        SVCodeOutput(content="1", id="call_1"),
+        SVStreamEnd(content="Done"),
     ]
     out = cleanup_conversation(conv, append_stream_end=True)
     kinds = [v.variant for v in out]
@@ -47,11 +47,11 @@ def test_cleanup_no_extra_end_if_existing():
 
 def test_normalize_conv_for_prompt_filters_meta():
     conv: list[StreamVariant] = [
-        SVServerHint(data={"thread_id": "abc"}),
-        SVUser(text="hi"),
-        SVAssistant(text="hello"),
-        SVServerError(message="oops"),
-        SVStreamEnd(message="Done"),
+        SVServerHint(content={"thread_id": "abc"}),
+        SVUser(content="hi"),
+        SVAssistant(content="hello"),
+        SVServerError(content="oops"),
+        SVStreamEnd(content="Done"),
     ]
     out = normalize_conv_for_prompt(conv, include_meta=False)
     # Meta variants removed
@@ -61,9 +61,9 @@ def test_normalize_conv_for_prompt_filters_meta():
 
 def test_ccrm_conversion_basic():
     conv: list[StreamVariant] = [
-        SVUser(text="hi"),
-        SVAssistant(text="hello"),
-        SVStreamEnd(message="Done"),
+        SVUser(content="hi"),
+        SVAssistant(content="hello"),
+        SVStreamEnd(content="Done"),
     ]
     msgs = help_convert_sv_ccrm(conv, include_images=False, include_meta=False)
     assert msgs[0]["role"] == "user"
@@ -72,8 +72,8 @@ def test_ccrm_conversion_basic():
 
 
 def test_wire_roundtrip():
-    original = SVCode(code="x=1", id="cid")
+    original = SVCode(content="x=1", id="cid")
     wire = from_sv_to_json(original)
-    assert wire == {"variant": "Code", "content": "x=1", "id": "cid"}
+    assert wire == {"variant": "Code", "content": "x=1", "id": "cid", "feedback": ""}
     back = from_json_to_sv(wire)
     assert back == original  # pydantic models are comparable

--- a/tests/unit_tests/test_thread_storage.py
+++ b/tests/unit_tests/test_thread_storage.py
@@ -29,20 +29,20 @@ async def test_save_and_read_thread(monkeypatch, patch_mongodb, GOOD_HEADERS):
     await storage.save_thread(
         thread_id=tid,
         user_id=user_id,
-        content=[SVPrompt(payload='[{"role":"system","content":"s"}]')],
+        content=[SVPrompt(content='[{"role":"system","content":"s"}]')],
         append_to_existing=True,
     )
     # write user + assistant + explicit end
     await storage.save_thread(
         thread_id=tid,
         user_id=user_id,
-        content=[SVUser(text="hi")],
+        content=[SVUser(content="hi")],
         append_to_existing=True,
     )
     await storage.save_thread(
         thread_id=tid,
         user_id=user_id,
-        content=[SVAssistant(text="hello"), SVStreamEnd(message="Done")],
+        content=[SVAssistant(content="hello"), SVStreamEnd(content="Done")],
         append_to_existing=True,
     )
 


### PR DESCRIPTION
This PR simplifies StreamVariant handling by aligning internal model attributes with the client-facing wire format, reducing conversion boilerplate and separating OpenAI-specific helpers from the core variant definitions.

**Changes:**
- Renamed `StreamVariant` payload fields to consistently use content across user, assistant, code, tool, image, server hint/error, and stream end variants.
- Moved OpenAI chat conversion utilities and MCP tool schema conversion into a new `openai_helpers.py` module.