### PR TITLE
Stream heartbeat to the client while waiting for model response

### DIFF
--- a/src/climateclaw/services/streaming/stream_orchestrator.py
+++ b/src/climateclaw/services/streaming/stream_orchestrator.py
@@ -48,6 +48,7 @@ from climateclaw.services.streaming.tool_calls import (
 )
 
 DEFAULT_LOGGER = configure_logging(__name__)
+HEARTBEAT_INTERVAL_SECONDS = 1
 
 
 @dataclass
@@ -56,6 +57,18 @@ class StreamState:
     tool_call: dict[str, Any] | None = None
     finished: bool = False
     replay_gate: ReplayGate | None = None
+
+
+async def _yield_heartbeats_until(
+    task: asyncio.Task[Any],
+    *,
+    interval: float = HEARTBEAT_INTERVAL_SECONDS,
+) -> AsyncIterator[SVServerHint]:
+    while not task.done():
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=interval)
+        except TimeoutError:
+            yield await heartbeat_content()
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -99,17 +112,48 @@ async def stream_with_tools(
     tools = await mcp.openai_tools() if mcp and hasattr(mcp, "openai_tools") else []
 
     if tools:
-        resp = await acomplete_func(
-            model=model, messages=messages, stream=True, tools=tools, tool_choice="auto"
+        resp_task = asyncio.create_task(
+            acomplete_func(
+                model=model,
+                messages=messages,
+                stream=True,
+                tools=tools,
+                tool_choice="auto",
+            )
         )
     else:
-        resp = await acomplete_func(model=model, messages=messages, stream=True)
+        resp_task = asyncio.create_task(
+            acomplete_func(model=model, messages=messages, stream=True)
+        )
+
+    try:
+        async for hb in _yield_heartbeats_until(resp_task):
+            yield hb
+        resp = await resp_task
+    except asyncio.CancelledError:
+        resp_task.cancel()
+        await asyncio.gather(resp_task, return_exceptions=True)
+        raise
 
     accumulated_asst_text: list[str] = []
 
     if hasattr(resp, "__aiter__"):
         call_id = ""
-        async for chunk in resp:
+        stream_iter = resp.__aiter__()
+        while True:
+            chunk_task = asyncio.create_task(stream_iter.__anext__())
+
+            try:
+                async for hb in _yield_heartbeats_until(chunk_task):
+                    yield hb
+                chunk = await chunk_task
+            except StopAsyncIteration:
+                break
+            except asyncio.CancelledError:
+                chunk_task.cancel()
+                await asyncio.gather(chunk_task, return_exceptions=True)
+                raise
+
             choice = (chunk.get("choices") or [{}])[0]
             delta = choice.get("delta") or {}
 
@@ -189,7 +233,7 @@ async def stream_with_tools(
         )
 
         async def run_with_heartbeat():
-            """Run the tool while periodically sending heartbeats."""
+            """Run the tool while sending heartbeats during quiet periods."""
             tool_task = asyncio.create_task(
                 run_tool_via_mcp(
                     mcp=mcp,
@@ -202,11 +246,8 @@ async def stream_with_tools(
             await register_tool_task(thread_id, tool_task)
 
             try:
-                # While tool runs, emit heartbeats every few seconds
-                while not tool_task.done():
-                    hb = await heartbeat_content()
+                async for hb in _yield_heartbeats_until(tool_task):
                     yield hb
-                    await asyncio.sleep(10)  # heartbeat interval (seconds)
 
                 # When done, return the final result text
                 result_text = await tool_task

--- a/tests/unit_tests/test_stream_heartbeat.py
+++ b/tests/unit_tests/test_stream_heartbeat.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import pytest
+
+from climateclaw.services.streaming import stream_orchestrator
+from climateclaw.services.streaming.stream_variants import SVServerHint
+
+
+@pytest.mark.asyncio
+async def test_yield_heartbeats_until_emits_after_quiet_period(monkeypatch):
+    async def fake_heartbeat_content():
+        return SVServerHint(content={"heartbeat": True})
+
+    async def slow_task():
+        await asyncio.sleep(0.03)
+        return "done"
+
+    monkeypatch.setattr(
+        stream_orchestrator, "heartbeat_content", fake_heartbeat_content
+    )
+
+    task = asyncio.create_task(slow_task())
+    heartbeats = [
+        item
+        async for item in stream_orchestrator._yield_heartbeats_until(
+            task, interval=0.01
+        )
+    ]
+
+    assert await task == "done"
+    assert heartbeats
+    assert all(isinstance(item, SVServerHint) for item in heartbeats)
+
+
+@pytest.mark.asyncio
+async def test_yield_heartbeats_until_is_quiet_for_fast_task(monkeypatch):
+    async def fake_heartbeat_content():
+        return SVServerHint(data={"heartbeat": True})
+
+    async def fast_task():
+        return "done"
+
+    monkeypatch.setattr(
+        stream_orchestrator, "heartbeat_content", fake_heartbeat_content
+    )
+
+    task = asyncio.create_task(fast_task())
+    heartbeats = [
+        item
+        async for item in stream_orchestrator._yield_heartbeats_until(
+            task, interval=0.01
+        )
+    ]
+
+    assert await task == "done"
+    assert heartbeats == []

--- a/tests/unit_tests/test_stream_orchestrator.py
+++ b/tests/unit_tests/test_stream_orchestrator.py
@@ -1,0 +1,56 @@
+import pytest
+
+from climateclaw.services.streaming.stream_orchestrator import (
+    StreamState,
+    stream_with_tools,
+)
+from climateclaw.services.streaming.stream_variants import SVAssistant, SVStreamEnd
+
+
+async def fake_assistant_stream():
+    yield {
+        "choices": [
+            {
+                "delta": {"content": "hello "},
+                "finish_reason": None,
+            }
+        ]
+    }
+    yield {
+        "choices": [
+            {
+                "delta": {"content": "world"},
+                "finish_reason": "stop",
+            }
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_stream_with_tools_consumes_async_iterator_response(
+    patch_registry, patch_thread_storage
+):
+    patch_registry({"t-stream": []})
+
+    async def fake_acomplete(**kwargs):
+        assert kwargs["stream"] is True
+        return fake_assistant_stream()
+
+    items = [
+        item
+        async for item in stream_with_tools(
+            model="test-model",
+            thread_id="t-stream",
+            messages=[],
+            acomplete_func=fake_acomplete,
+            stream_state=StreamState(),
+            storage=patch_thread_storage,
+            store_thread=False,
+        )
+    ]
+
+    assert items == [
+        SVAssistant(content="hello "),
+        SVAssistant(content="world"),
+        SVStreamEnd(content="Stream ended."),
+    ]


### PR DESCRIPTION
This PR adds heartbeat streaming while waiting on slow model responses and stream chunks. It (hopefully) reduces client-side idle timeouts by emitting heartbeat events during quiet periods without changing the actual model or tool output behavior. This is especially useful for local models, as they take longer to respond and they don't stream the tool content. Consequently the user experiences a long and unexplained pause. With the heartbeats, the client is informed that the backend is waiting on other processes.
Previously the heartbeat was only sent while waiting for response to tool-calls.
This closes #72 .

**Changes:**
- Adds a shared heartbeat helper for awaiting async tasks while periodically yielding heartbeat content.
- Sends heartbeats while waiting for the initial model streaming response to start.
- Sends heartbeats between streamed model chunks when the model is slow to produce the next chunk.
- Reuses the same heartbeat behavior during MCP tool execution, replacing the previous implementation.