### PR TITLE
Fix/dev scaled build once

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 #   --debug=0 / --DEBUG=0      -> DEBUG=0
 #   --no-debug                 -> DEBUG=0
 #   --scale                    -> use scaling with load-balancing proxy
+#   --build                    -> build images before running compose
 #
 # Everything else is passed through to `docker compose`.
 # ------------------------------------------------------------------
@@ -23,6 +24,7 @@ Custom options:
   --debug=VALUE     Set debug explicitly, e.g. --debug=0 or --debug=1
   --no-debug        Disable debug mode
   --scale           Generate and use docker-compose.dev.scaled.yml
+  --build           Build images before starting
 
 Examples:
   ./dev.sh up
@@ -42,6 +44,8 @@ export CLIMATECLAW_DEV=1
 
 CLIMATECLAW_DEBUG="${CLIMATECLAW_DEBUG:-0}"
 COMPOSE_FILE="docker-compose.dev.yml"
+BUILD_COMPOSE_FILE="${COMPOSE_FILE}"
+DO_BUILD=0
 COMPOSE_ARGS=()
 
 for arg in "$@"; do
@@ -68,6 +72,10 @@ for arg in "$@"; do
       ./gen_compose.py ${COMPOSE_FILE}
       COMPOSE_FILE="docker-compose.dev.scaled.yml"
       ;;
+    # Build images once from the unscaled compose file.
+    --build)
+      DO_BUILD=1
+      ;;
     # Everything else goes to docker compose
     *)
       COMPOSE_ARGS+=("$arg")
@@ -81,5 +89,9 @@ export CLIMATECLAW_DEBUG
 echo "[dev.sh] Using ${COMPOSE_FILE} with DEBUG=${CLIMATECLAW_DEBUG}"
 echo "[dev.sh] docker compose -f ${COMPOSE_FILE} ${COMPOSE_ARGS[*]}"
 
-docker compose -f "${COMPOSE_FILE}" --profile build-only build climateclaw-base
+docker compose -f "${BUILD_COMPOSE_FILE}" --profile build-only build climateclaw-base
+if [ "${DO_BUILD}" = "1" ]; then
+  echo "[dev.sh] Building images from ${BUILD_COMPOSE_FILE}"
+  docker compose -f "${BUILD_COMPOSE_FILE}" build
+fi
 docker compose -f "${COMPOSE_FILE}" "${COMPOSE_ARGS[@]}"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -311,7 +311,7 @@ services:
 
   freva-rest-server:
     user: root
-    image: ghcr.io/freva-org/freva-rest-api:latest
+    image: ghcr.io/freva-org/freva-rest-api:2607.0.0
     hostname: restapi
     networks:
       - climateclaw

--- a/prod.sh
+++ b/prod.sh
@@ -88,6 +88,9 @@ for arg in "$@"; do
     fi
 done
 
+echo "[prod.sh] Building climateclaw-base from ${COMPOSE_FILE}"
+${COMPOSE} -f "${COMPOSE_FILE}" --profile build-only build climateclaw-base
+
 if [ "$do_build" = true ]; then
     echo "[prod.sh] Building images ..."
     ${COMPOSE} -f "${COMPOSE_FILE}" build


### PR DESCRIPTION
This PR fixes scaled builds in local dev by handling `--build` in `dev.sh` before invoking the scaled Compose file.
Previously, running `./dev.sh --scale up --build` forwarded `--build` to `docker compose -f docker-compose.dev.scaled.yml`, causing every generated replica service to build and export the same image tag. With multiple replicas, this leads to errors like:
`failed to solve: image "docker.io/library/code-server-dev:latest" already exists`

**Changes:**
- Treat `--build` as a `dev.sh` option instead of forwarding it to Compose.
- When `--build` is requested, build images once from the unscaled docker-compose.dev.yml.
- Start the selected Compose file afterward without --build, including docker-compose.dev.scaled.yml when --scale is used.
- Build `climateclaw-base` explicitly from compose file in `prod.sh` and `dev.sh`.