### PR TITLE
Remove duplicate preview mounts

### DIFF
--- a/gen_compose.py
+++ b/gen_compose.py
@@ -24,14 +24,8 @@ DEV_MODE = os.environ.get("CLIMATECLAW_DEV", "0")
 PREVIEW_MOUNTS = {
     "codes": ["/work/kd1418/codes/work/share/preview/climateclaw"],
     "eve": ["/work/ch1187/clint/freva-dev/share/preview/climateclaw"],
-    "freva-dev": [
-        "/work/ch1187/clint/freva-dev/share/preview/climateclaw",
-        "/work/ch1187/clint/nextgems/share/preview/climateclaw",
-    ],
-    "nextgems": [
-        "/work/ch1187/clint/freva-dev/share/preview/climateclaw",
-        "/work/ch1187/clint/nextgems/share/preview/climateclaw",
-    ],
+    "freva-dev": ["/work/ch1187/clint/freva-dev/share/preview/climateclaw"],
+    "nextgems": ["/work/ch1187/clint/nextgems/share/preview/climateclaw"],
     "regiklim-ces": ["/work/ch1187/regiklim-work/share/preview/climateclaw"],
     "xces": ["/work/bm1159/XCES/xces-work/share/preview/climateclaw"],
 }

--- a/tests/unit_tests/test_gen_compose.py
+++ b/tests/unit_tests/test_gen_compose.py
@@ -17,7 +17,6 @@ spec.loader.exec_module(gen_compose)
 
 def test_project_mapping_returns_preview_mounts_and_website():
     assert gen_compose.preview_paths_for_project("nextgems") == [
-        "/work/ch1187/clint/freva-dev/share/preview/climateclaw",
         "/work/ch1187/clint/nextgems/share/preview/climateclaw",
     ]
     assert gen_compose.website_for_project("nextgems") == "https://gems.dkrz.de"


### PR DESCRIPTION
This PR fixes duplicate preview mount configuration in gen_compose.py. Previously, the freva-dev and nextgems environments mounted both preview paths, which cause duplicated preview directory mounts. This change makes each environment mount only its own corresponding preview path.